### PR TITLE
vidc: drop clock ids usage

### DIFF
--- a/platform/common/inc/msm_vidc_platform.h
+++ b/platform/common/inc/msm_vidc_platform.h
@@ -60,7 +60,6 @@ struct regulator_table {
 
 struct clk_table {
 	const char      *name;
-	u32              clk_id;
 	bool             scaling;
 };
 

--- a/platform/qcm6490/src/msm_vidc_qcm6490.c
+++ b/platform/qcm6490/src/msm_vidc_qcm6490.c
@@ -4,9 +4,6 @@
  * Copyright (c) 2021-2024 Qualcomm Innovation Center, Inc. All rights reserved.
  */
 
-#include <dt-bindings/clock/qcom,gcc-sc7280.h>
-#include <dt-bindings/clock/qcom,videocc-sc7280.h>
-
 #include <linux/soc/qcom/llcc-qcom.h>
 
 #include <media/v4l2_vidc_extensions.h>
@@ -2297,11 +2294,11 @@ static const struct pd_table qcm6490_pd_table[] = {
 
 /* name, clock id, scaling */
 static const struct clk_table qcm6490_clk_table[] = {
-    { "bus",     VIDEO_CC_MVSC_CTL_AXI_CLK,      0 },
-    { "iface",   VIDEO_CC_VENUS_AHB_CLK,         0 },
-    { "vcodec_core",     VIDEO_CC_MVS0_CORE_CLK, 1},
-    { "core",      VIDEO_CC_MVSC_CORE_CLK,       1 },
-    { "vcodec_bus",  VIDEO_CC_MVS0_AXI_CLK,      0 },
+    { "bus",		0 },
+    { "iface",		0 },
+    { "vcodec_core",	1 },
+    { "core",		1 },
+    { "vcodec_bus",	0 },
 
 };
 

--- a/platform/qcs8300/src/msm_vidc_qcs8300.c
+++ b/platform/qcs8300/src/msm_vidc_qcs8300.c
@@ -4,8 +4,6 @@
  * Copyright (c) 2021-2022, 2024 Qualcomm Innovation Center, Inc. All rights reserved.
  */
 
-#include <dt-bindings/clock/qcom,qcs8300-gcc.h>
-#include <dt-bindings/clock/qcom,sa8775p-videocc.h>
 #include <media/v4l2_vidc_extensions.h>
 #include "hfi_command.h"
 #include "hfi_property.h"
@@ -2359,9 +2357,9 @@ static const char * const qcs8300_opp_pd_table[] = { "mx", "mmcx", NULL };
 
 /* name, clock id, scaling */
 static const struct clk_table qcs8300_clk_table[] = {
-	{ "iface",         GCC_VIDEO_AXI0_CLK,     0 },
-	{ "core",          VIDEO_CC_MVS0C_CLK,     0 },
-	{ "vcodec0_core",  VIDEO_CC_MVS0_CLK,      1 },
+	{ "iface",         0 },
+	{ "core",          0 },
+	{ "vcodec0_core",  1 },
 };
 
 /* name, exclusive_release */

--- a/platform/sa8775p/src/msm_vidc_sa8775p.c
+++ b/platform/sa8775p/src/msm_vidc_sa8775p.c
@@ -4,8 +4,6 @@
  * Copyright (c) 2021-2022, 2024 Qualcomm Innovation Center, Inc. All rights reserved.
  */
 
-#include <dt-bindings/clock/qcom,sa8775p-gcc.h>
-#include <dt-bindings/clock/qcom,sa8775p-videocc.h>
 #include <media/v4l2_vidc_extensions.h>
 #include "hfi_command.h"
 #include "hfi_property.h"
@@ -2515,9 +2513,9 @@ static const char * const sa8775p_opp_pd_table[] = { "mxc", "mmcx", NULL };
 
 /* name, clock id, scaling */
 static const struct clk_table sa8775p_clk_table[] = {
-	{ "iface",         GCC_VIDEO_AXI0_CLK,     0 },
-	{ "core",          VIDEO_CC_MVS0C_CLK,     0 },
-	{ "vcodec0_core",  VIDEO_CC_MVS0_CLK,      1 },
+	{ "iface",         0 },
+	{ "core",          0 },
+	{ "vcodec0_core",  1 },
 };
 
 /* name, exclusive_release */

--- a/vidc/inc/resources.h
+++ b/vidc/inc/resources.h
@@ -153,7 +153,6 @@ struct clock_residency {
 struct clock_info {
 	struct clk                *clk;
 	const char                *name;
-	u32                        clk_id;
 	bool                       has_scaling;
 	u64                        prev;
 #ifdef CONFIG_MSM_MMRM

--- a/vidc/src/resources.c
+++ b/vidc/src/resources.c
@@ -462,7 +462,6 @@ static int __init_clocks(struct msm_vidc_core *core)
 	/* populate clock field from platform data */
 	for (cnt = 0; cnt < clocks->count; cnt++) {
 		clocks->clock_tbl[cnt].name = clk_tbl[cnt].name;
-		clocks->clock_tbl[cnt].clk_id = clk_tbl[cnt].clk_id;
 		clocks->clock_tbl[cnt].has_scaling = clk_tbl[cnt].scaling;
 	}
 
@@ -504,8 +503,8 @@ static int __init_clocks(struct msm_vidc_core *core)
 
 	/* print clock fields */
 	venus_hfi_for_each_clock(core, cinfo) {
-		d_vpr_h("%s: clock name %s clock id %#x scaling %d\n",
-			__func__, cinfo->name, cinfo->clk_id, cinfo->has_scaling);
+		d_vpr_h("%s: clock name %s scaling %d\n",
+			__func__, cinfo->name, cinfo->has_scaling);
 	}
 
 	/* get clock handle */


### PR DESCRIPTION
Video driver isn't supposed to use clock controller _bindings_, they are the contract between clock controller driver and the DT. Stop using clock ids and drop corresponding fields. The only actual user is under the CONFIG_MSM_MMRM, which is not supported upstream.