### PR TITLE
video: driver: Add support for upstream device tree compatibility

### DIFF
--- a/vidc/inc/msm_vidc_core.h
+++ b/vidc/inc/msm_vidc_core.h
@@ -127,6 +127,7 @@ struct msm_vidc_core {
 	u32                                    packet_id;
 	u32                                    sys_init_id;
 	struct msm_vidc_synx_fence_data        synx_fence_data;
+	int                                    cb_count;
 };
 
 #endif // _MSM_VIDC_CORE_H_

--- a/vidc/src/msm_vidc_driver.c
+++ b/vidc/src/msm_vidc_driver.c
@@ -5585,11 +5585,14 @@ struct context_bank_info *msm_vidc_get_context_bank_for_device(
 	struct context_bank_info *cb = NULL, *match = NULL;
 
 	venus_hfi_for_each_context_bank(core, cb) {
-		if (of_device_is_compatible(dev->of_node, cb->name)) {
+		if (!core->cb_count && !strcmp("qcom,vidc,cb-ns", cb->name))
 			match = cb;
+		else if (of_device_is_compatible(dev->of_node, cb->name))
+			match = cb;
+		if (match)
 			break;
-		}
 	}
+
 	if (!match)
 		d_vpr_e("cb not found for dev %s\n", dev_name(dev));
 


### PR DESCRIPTION
The downstream video driver expects context banks as device tree sub-nodes, while the upstream device tree omits them, causing incompatibility.

This patch updates the downstream driver to handle the absence of context bank sub-nodes, allowing it to work with the upstream device tree and kernel.

Change-Id: I6dc509e40a6c2757f3bd42761edb6d5cd1d71611