### PR TITLE
video: driver: update the firmware to pick the upstream bins

### DIFF
--- a/platform/sa8775p/src/msm_vidc_sa8775p.c
+++ b/platform/sa8775p/src/msm_vidc_sa8775p.c
@@ -2667,7 +2667,7 @@ static const struct msm_vidc_platform_data sa8775p_data = {
 	.freq_tbl_size = ARRAY_SIZE(sa8775p_freq_table),
 	.reg_prst_tbl = sa8775p_reg_preset_table,
 	.reg_prst_tbl_size = ARRAY_SIZE(sa8775p_reg_preset_table),
-	.fwname = "./qcom/vpu-3.0/vpu30_4v_16mb",
+	.fwname = "./qcom/vpu/vpu30_p4_s6",
 	.pas_id = 9,
 	.supports_mmrm = 0,
 


### PR DESCRIPTION
Driver code currently picks the firmware from a proprietary git repo, update the same to pick from standard firmware repo.