### PR TITLE
Video driver PR consisting of enablement fixes for QCS8300 and SA8775p

### DIFF
--- a/platform/qcm6490/src/msm_vidc_qcm6490.c
+++ b/platform/qcm6490/src/msm_vidc_qcm6490.c
@@ -2419,7 +2419,7 @@ static const struct msm_vidc_platform_data qcm6490_data = {
 #endif
     .pd_tbl = qcm6490_pd_table,
     .pd_tbl_size = ARRAY_SIZE(qcm6490_pd_table),
-    .fwname = "qcom/vpu-2.0/vpu20_1v",
+    .fwname = "./qcom/vpu/vpu20_p1_gen2.mbn",
     .pas_id = 9,
     .supports_mmrm = 0,
 

--- a/platform/qcs8300/src/msm_vidc_qcs8300.c
+++ b/platform/qcs8300/src/msm_vidc_qcs8300.c
@@ -2353,7 +2353,7 @@ static const struct pd_table qcs8300_pd_table[] = {
 };
 
 /* name */
-static const char * const qcs8300_opp_pd_table[] = { "mx", "mmcx", NULL };
+static const char * const qcs8300_opp_pd_table[] = { "mxc", "mmcx", NULL };
 
 /* name, clock id, scaling */
 static const struct clk_table qcs8300_clk_table[] = {
@@ -2512,7 +2512,7 @@ static const struct msm_vidc_platform_data qcs8300_data = {
 	.freq_tbl_size = ARRAY_SIZE(qcs8300_freq_table),
 	.reg_prst_tbl = qcs8300_reg_preset_table,
 	.reg_prst_tbl_size = ARRAY_SIZE(qcs8300_reg_preset_table),
-	.fwname = "./qcom/vpu-3.0/vpu30_4v",
+	.fwname = "./qcom/vpu/vpu30_p4_s6.mbn",
 	.pas_id = 9,
 	.supports_mmrm = 0,
 

--- a/platform/sa8775p/src/msm_vidc_sa8775p.c
+++ b/platform/sa8775p/src/msm_vidc_sa8775p.c
@@ -2667,7 +2667,7 @@ static const struct msm_vidc_platform_data sa8775p_data = {
 	.freq_tbl_size = ARRAY_SIZE(sa8775p_freq_table),
 	.reg_prst_tbl = sa8775p_reg_preset_table,
 	.reg_prst_tbl_size = ARRAY_SIZE(sa8775p_reg_preset_table),
-	.fwname = "./qcom/vpu-3.0/vpu30_4v_16mb",
+	.fwname = "./qcom/vpu/vpu30_p4_s6.mbn",
 	.pas_id = 9,
 	.supports_mmrm = 0,
 

--- a/vidc/src/firmware.c
+++ b/vidc/src/firmware.c
@@ -79,7 +79,6 @@ static int __load_fw_to_memory(struct platform_device *pdev,
 	int rc = 0;
 	const struct firmware *firmware = NULL;
 	struct msm_vidc_core *core;
-	char firmware_name[MAX_FIRMWARE_NAME_SIZE] = { 0 };
 	struct device_node *node = NULL;
 	struct resource res = { 0 };
 	phys_addr_t phys = 0;
@@ -103,7 +102,6 @@ static int __load_fw_to_memory(struct platform_device *pdev,
 			__func__, dev_name(&pdev->dev));
 		return -EINVAL;
 	}
-	scnprintf(firmware_name, ARRAY_SIZE(firmware_name), "%s.mbn", fw_name);
 
 	pas_id = core->platform->data.pas_id;
 
@@ -123,10 +121,10 @@ static int __load_fw_to_memory(struct platform_device *pdev,
 	phys = res.start;
 	res_size = (size_t)resource_size(&res);
 
-	rc = request_firmware(&firmware, firmware_name, &pdev->dev);
+	rc = request_firmware(&firmware, fw_name, &pdev->dev);
 	if (rc) {
 		d_vpr_e("%s: failed to request fw \"%s\", error %d\n",
-			__func__, firmware_name, rc);
+			__func__, fw_name, rc);
 		goto exit;
 	}
 
@@ -147,25 +145,25 @@ static int __load_fw_to_memory(struct platform_device *pdev,
 
 	/* prevent system suspend during fw_load */
 	pm_stay_awake(pdev->dev.parent);
-	rc = qcom_mdt_load(&pdev->dev, firmware, firmware_name,
-			   pas_id, virt, phys, res_size, NULL);
+	rc = qcom_mdt_load(&pdev->dev, firmware, fw_name, pas_id, virt,
+			   phys, res_size, NULL);
 	pm_relax(pdev->dev.parent);
 	if (rc) {
 		d_vpr_e("%s: error %d loading fw \"%s\"\n",
-			__func__, rc, firmware_name);
+			__func__, rc, fw_name);
 		goto exit;
 	}
 	rc = qcom_scm_pas_auth_and_reset(pas_id);
 	if (rc) {
 		d_vpr_e("%s: error %d authenticating fw \"%s\"\n",
-			__func__, rc, firmware_name);
+			__func__, rc, fw_name);
 		goto exit;
 	}
 
 	memunmap(virt);
 	release_firmware(firmware);
 	d_vpr_h("%s: firmware \"%s\" loaded successfully\n",
-		__func__, firmware_name);
+		__func__, fw_name);
 
 	return pas_id;
 
@@ -180,11 +178,15 @@ exit:
 
 int fw_load(struct msm_vidc_core *core)
 {
+	const char *fwpath = NULL;
 	int rc;
 
+	rc = of_property_read_string_index(core->pdev->dev.of_node, "firmware-name", 0, &fwpath);
+	if (rc)
+		fwpath = core->platform->data.fwname;
+
 	if (!core->resource->fw_cookie) {
-		core->resource->fw_cookie = __load_fw_to_memory(core->pdev,
-								core->platform->data.fwname);
+		core->resource->fw_cookie = __load_fw_to_memory(core->pdev, fwpath);
 		if (core->resource->fw_cookie <= 0) {
 			d_vpr_e("%s: firmware download failed %d\n",
 				__func__, core->resource->fw_cookie);


### PR DESCRIPTION
This PR contains:
- Fix the firmware path to point to upstream firmware repo for QCS8300, QCM6490 and SA8775p
- Update the driver such that the firmware path is fetched from board file. Incase board file does not mention it, pick the one defined in SOC platform data in driver.