### PR TITLE
video-driver PR consisting of changes to enable video on qcm6490 and a colorspace fix

### DIFF
--- a/platform/common/src/msm_vidc_platform.c
+++ b/platform/common/src/msm_vidc_platform.c
@@ -205,7 +205,7 @@ static const struct msm_vidc_compat_handle compat_handle[] = {
 		.init_iris                  = msm_vidc_init_iris3,
 	},
 	{
-		.compat                     = "qcom,qcm6490-iris-vpu",
+		.compat                     = "qcom,sc7280-venus",
 		.init_platform              = msm_vidc_init_platform_qcm6490,
 		.init_iris                  = msm_vidc_init_iris2,
 	},

--- a/platform/qcm6490/src/msm_vidc_qcm6490.c
+++ b/platform/qcm6490/src/msm_vidc_qcm6490.c
@@ -2281,8 +2281,8 @@ static struct msm_vidc_format_capability format_data_qcm6490 = {
 
 /* name, min_kbps, max_kbps */
 static const struct bw_table qcm6490_bw_table[] = {
-    { "iris-cnoc",  1000, 1000     },
-    { "iris-ddr",   1000, 10000000 }
+	{ "cpu-cfg", 1000, 1000     },
+	{ "video-mem", 1000, 10000000 }
 };
 
 /* name, hw_trigger */

--- a/platform/qcm6490/src/msm_vidc_qcm6490.c
+++ b/platform/qcm6490/src/msm_vidc_qcm6490.c
@@ -2292,6 +2292,9 @@ static const struct pd_table qcm6490_pd_table[] = {
     { "vcodec0" },
 };
 
+/*name*/
+static const char * const qcm6490_opp_table[] = { "cx", NULL };
+
 /* name, clock id, scaling */
 static const struct clk_table qcm6490_clk_table[] = {
     { "bus",		0 },
@@ -2413,10 +2416,8 @@ static const struct msm_vidc_platform_data qcm6490_data = {
     .freq_tbl_size = ARRAY_SIZE(qcm6490_freq_table_sku0),
     .reg_prst_tbl = qcm6490_reg_preset_table,
     .reg_prst_tbl_size = ARRAY_SIZE(qcm6490_reg_preset_table),
-#if 0
     .opp_tbl = qcm6490_opp_table,
     .opp_tbl_size = ARRAY_SIZE(qcm6490_opp_table),
-#endif
     .pd_tbl = qcm6490_pd_table,
     .pd_tbl_size = ARRAY_SIZE(qcm6490_pd_table),
     .fwname = "qcom/vpu-2.0/vpu20_1v",

--- a/platform/qcs8300/src/msm_vidc_qcs8300.c
+++ b/platform/qcs8300/src/msm_vidc_qcs8300.c
@@ -135,24 +135,12 @@ static struct color_primaries_info color_primaries_data_qcs8300[] = {
 		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_SMPTE_ST240M,
 	},
 	{
-		.v4l2_color_primaries  = V4L2_COLORSPACE_VIDC_GENERIC_FILM,
-		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_GENERIC_FILM,
-	},
-	{
 		.v4l2_color_primaries  = V4L2_COLORSPACE_BT2020,
 		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_BT2020,
 	},
 	{
 		.v4l2_color_primaries  = V4L2_COLORSPACE_DCI_P3,
 		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_SMPTE_RP431_2,
-	},
-	{
-		.v4l2_color_primaries  = V4L2_COLORSPACE_VIDC_EG431,
-		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_SMPTE_EG431_1,
-	},
-	{
-		.v4l2_color_primaries  = V4L2_COLORSPACE_VIDC_EBU_TECH,
-		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_SMPTE_EBU_TECH,
 	},
 };
 
@@ -170,52 +158,16 @@ static struct transfer_char_info transfer_char_data_qcs8300[] = {
 		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT709,
 	},
 	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_BT470_SYSTEM_M,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT470_SYSTEM_M,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_BT470_SYSTEM_BG,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT470_SYSTEM_BG,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_BT601_525_OR_625,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT601_525_OR_625,
-	},
-	{
 		.v4l2_transfer_char  = V4L2_XFER_FUNC_SMPTE240M,
 		.vidc_transfer_char  = MSM_VIDC_TRANSFER_SMPTE_ST240M,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_LINEAR,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_LINEAR,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_XVYCC,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_XVYCC,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_BT1361,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT1361_0,
 	},
 	{
 		.v4l2_transfer_char  = V4L2_XFER_FUNC_SRGB,
 		.vidc_transfer_char  = MSM_VIDC_TRANSFER_SRGB_SYCC,
 	},
 	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_BT2020,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT2020_14,
-	},
-	{
 		.v4l2_transfer_char  = V4L2_XFER_FUNC_SMPTE2084,
 		.vidc_transfer_char  = MSM_VIDC_TRANSFER_SMPTE_ST2084_PQ,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_ST428,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_SMPTE_ST428_1,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_HLG,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT2100_2_HLG,
 	},
 };
 
@@ -229,20 +181,12 @@ static struct matrix_coeff_info matrix_coeff_data_qcs8300[] = {
 		.vidc_matrix_coeff  = MSM_VIDC_MATRIX_COEFF_UNSPECIFIED,
 	},
 	{
-		.v4l2_matrix_coeff  = V4L2_YCBCR_VIDC_SRGB_OR_SMPTE_ST428,
-		.vidc_matrix_coeff  = MSM_VIDC_MATRIX_COEFF_SRGB_SMPTE_ST428_1,
-	},
-	{
 		.v4l2_matrix_coeff  = V4L2_YCBCR_ENC_709,
 		.vidc_matrix_coeff  = MSM_VIDC_MATRIX_COEFF_BT709,
 	},
 	{
 		.v4l2_matrix_coeff  = V4L2_YCBCR_ENC_XV709,
 		.vidc_matrix_coeff  = MSM_VIDC_MATRIX_COEFF_BT709,
-	},
-	{
-		.v4l2_matrix_coeff  = V4L2_YCBCR_VIDC_FCC47_73_682,
-		.vidc_matrix_coeff  = MSM_VIDC_MATRIX_COEFF_FCC_TITLE_47,
 	},
 	{
 		.v4l2_matrix_coeff  = V4L2_YCBCR_ENC_XV601,

--- a/platform/sa8775p/src/msm_vidc_sa8775p.c
+++ b/platform/sa8775p/src/msm_vidc_sa8775p.c
@@ -140,24 +140,12 @@ static struct color_primaries_info color_primaries_data_sa8775p[] = {
 		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_SMPTE_ST240M,
 	},
 	{
-		.v4l2_color_primaries  = V4L2_COLORSPACE_VIDC_GENERIC_FILM,
-		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_GENERIC_FILM,
-	},
-	{
 		.v4l2_color_primaries  = V4L2_COLORSPACE_BT2020,
 		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_BT2020,
 	},
 	{
 		.v4l2_color_primaries  = V4L2_COLORSPACE_DCI_P3,
 		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_SMPTE_RP431_2,
-	},
-	{
-		.v4l2_color_primaries  = V4L2_COLORSPACE_VIDC_EG431,
-		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_SMPTE_EG431_1,
-	},
-	{
-		.v4l2_color_primaries  = V4L2_COLORSPACE_VIDC_EBU_TECH,
-		.vidc_color_primaries  = MSM_VIDC_PRIMARIES_SMPTE_EBU_TECH,
 	},
 };
 
@@ -175,52 +163,16 @@ static struct transfer_char_info transfer_char_data_sa8775p[] = {
 		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT709,
 	},
 	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_BT470_SYSTEM_M,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT470_SYSTEM_M,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_BT470_SYSTEM_BG,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT470_SYSTEM_BG,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_BT601_525_OR_625,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT601_525_OR_625,
-	},
-	{
 		.v4l2_transfer_char  = V4L2_XFER_FUNC_SMPTE240M,
 		.vidc_transfer_char  = MSM_VIDC_TRANSFER_SMPTE_ST240M,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_LINEAR,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_LINEAR,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_XVYCC,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_XVYCC,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_BT1361,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT1361_0,
 	},
 	{
 		.v4l2_transfer_char  = V4L2_XFER_FUNC_SRGB,
 		.vidc_transfer_char  = MSM_VIDC_TRANSFER_SRGB_SYCC,
 	},
 	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_BT2020,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT2020_14,
-	},
-	{
 		.v4l2_transfer_char  = V4L2_XFER_FUNC_SMPTE2084,
 		.vidc_transfer_char  = MSM_VIDC_TRANSFER_SMPTE_ST2084_PQ,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_ST428,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_SMPTE_ST428_1,
-	},
-	{
-		.v4l2_transfer_char  = V4L2_XFER_FUNC_VIDC_HLG,
-		.vidc_transfer_char  = MSM_VIDC_TRANSFER_BT2100_2_HLG,
 	},
 };
 
@@ -234,20 +186,12 @@ static struct matrix_coeff_info matrix_coeff_data_sa8775p[] = {
 		.vidc_matrix_coeff  = MSM_VIDC_MATRIX_COEFF_UNSPECIFIED,
 	},
 	{
-		.v4l2_matrix_coeff  = V4L2_YCBCR_VIDC_SRGB_OR_SMPTE_ST428,
-		.vidc_matrix_coeff  = MSM_VIDC_MATRIX_COEFF_SRGB_SMPTE_ST428_1,
-	},
-	{
 		.v4l2_matrix_coeff  = V4L2_YCBCR_ENC_709,
 		.vidc_matrix_coeff  = MSM_VIDC_MATRIX_COEFF_BT709,
 	},
 	{
 		.v4l2_matrix_coeff  = V4L2_YCBCR_ENC_XV709,
 		.vidc_matrix_coeff  = MSM_VIDC_MATRIX_COEFF_BT709,
-	},
-	{
-		.v4l2_matrix_coeff  = V4L2_YCBCR_VIDC_FCC47_73_682,
-		.vidc_matrix_coeff  = MSM_VIDC_MATRIX_COEFF_FCC_TITLE_47,
 	},
 	{
 		.v4l2_matrix_coeff  = V4L2_YCBCR_ENC_XV601,

--- a/vidc/src/msm_vidc_probe.c
+++ b/vidc/src/msm_vidc_probe.c
@@ -42,7 +42,7 @@ const char video_banner[] = "Video-Banner: (" __stringify(VIDEO_COMPILE_BY) "@"
 static inline bool is_video_device(struct device *dev)
 {
 	return !!(of_device_is_compatible(dev->of_node, "qcom,sm8550-vidc") ||
-		of_device_is_compatible(dev->of_node, "qcom,qcm6490-iris-vpu") ||
+		of_device_is_compatible(dev->of_node, "qcom,sc7280-venus") ||
 		of_device_is_compatible(dev->of_node, "qcom,sa8775p-iris") ||
 		of_device_is_compatible(dev->of_node, "qcom,qcs8300-iris"));
 }
@@ -114,7 +114,7 @@ static struct attribute_group msm_vidc_core_attr_group = {
 };
 
 static const struct of_device_id msm_vidc_dt_match[] = {
-	{.compatible = "qcom,qcm6490-iris-vpu"},
+	{.compatible = "qcom,sc7280-venus"},
 	{.compatible = "qcom,sm8550-vidc"},
 	{.compatible = "qcom,sa8775p-iris"},
 	{.compatible = "qcom,qcs8300-iris"},


### PR DESCRIPTION
This PR contains 
1) Changes to enable video on qcm6490 like compatible and other names to match with device tree
2) Fix to drop non standard color space types