### PR TITLE
video-driver: PR consisting of createbuf, mmap enablement and miscellaneous fixes

### DIFF
--- a/vidc/inc/msm_vidc_internal.h
+++ b/vidc/inc/msm_vidc_internal.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 /*
  * Copyright (c) 2020-2021, The Linux Foundation. All rights reserved.
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  */
 
 #ifndef _MSM_VIDC_INTERNAL_H_
@@ -961,6 +961,17 @@ struct msm_vidc_mem_list {
 	struct list_head            list; // list of "struct msm_vidc_mem"
 };
 
+struct msm_vidc_dma_buf_info  {
+	u32                       buffer_size;
+	u64                       device_addr;
+	unsigned long             dma_attrs;
+	refcount_t                refcount;
+	void                      *kvaddr;
+	struct vb2_vmarea_handler handler;
+	struct  msm_vidc_buffer   *buf;
+	struct  device            *dev;
+};
+
 struct msm_vidc_buffer {
 	struct list_head                   list;
 	struct msm_vidc_inst              *inst;
@@ -986,6 +997,7 @@ struct msm_vidc_buffer {
 	u64                                fence_id;
 	u32                                start_time_ms;
 	u32                                end_time_ms;
+	struct msm_vidc_dma_buf_info       *dma_buf_info;
 };
 
 struct msm_vidc_buffers {

--- a/vidc/inc/msm_vidc_vb2.h
+++ b/vidc/inc/msm_vidc_vb2.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 /*
  * Copyright (c) 2020-2021, The Linux Foundation. All rights reserved.
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  */
 
 #ifndef _MSM_VIDC_VB2_H_
@@ -31,7 +31,7 @@ void *msm_vb2_attach_dmabuf(struct vb2_buffer *vb, struct device *dev,
 #endif
 
 void msm_vb2_put(void *buf_priv);
-int msm_vb2_mmap(void *buf_priv, struct vm_area_struct *vma);
+int msm_vb2_mmap(void *dmabuf, struct vm_area_struct *vma);
 struct dma_buf *msm_vb2_get_dmabuf(struct vb2_buffer *vb,
 				   void *buf_priv,
 				   unsigned long flags);

--- a/vidc/src/msm_vdec.c
+++ b/vidc/src/msm_vdec.c
@@ -1344,6 +1344,9 @@ static int msm_vdec_read_input_subcr_params(struct msm_vidc_inst *inst)
 	inst->fmts[INPUT_PORT].fmt.pix_mp.width = width;
 	inst->fmts[INPUT_PORT].fmt.pix_mp.height = height;
 
+	if (subsc_params.bit_depth == BIT_DEPTH_10)
+		inst->fmts[OUTPUT_PORT].fmt.pix_mp.pixelformat = V4L2_PIX_FMT_QC10C;
+
 	output_fmt = v4l2_colorformat_to_driver(inst,
 		inst->fmts[OUTPUT_PORT].fmt.pix_mp.pixelformat, __func__);
 

--- a/vidc/src/msm_vdec.c
+++ b/vidc/src/msm_vdec.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2020-2021, The Linux Foundation. All rights reserved.
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  */
 
 #include "msm_media_info.h"
@@ -2583,6 +2583,11 @@ int msm_vdec_inst_init(struct msm_vidc_inst *inst)
 		inst->power.dcvs_mode = true;
 
 	f = &inst->fmts[INPUT_PORT];
+
+	inst->crop.left = inst->crop.top = 0;
+	inst->crop.width = f->fmt.pix_mp.width;
+	inst->crop.height = f->fmt.pix_mp.height;
+
 	f->type = INPUT_MPLANE;
 	f->fmt.pix_mp.width = DEFAULT_WIDTH;
 	f->fmt.pix_mp.height = DEFAULT_HEIGHT;
@@ -2600,10 +2605,6 @@ int msm_vdec_inst_init(struct msm_vidc_inst *inst)
 			inst->buffers.input.min_count +
 			inst->buffers.input.extra_count;
 	inst->buffers.input.size = f->fmt.pix_mp.plane_fmt[0].sizeimage;
-
-	inst->crop.left = inst->crop.top = 0;
-	inst->crop.width = f->fmt.pix_mp.width;
-	inst->crop.height = f->fmt.pix_mp.height;
 
 	f = &inst->fmts[INPUT_META_PORT];
 	f->type = INPUT_META_PLANE;

--- a/vidc/src/msm_vidc.c
+++ b/vidc/src/msm_vidc.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2020-2021, The Linux Foundation. All rights reserved.
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
  */
 
 #include <linux/types.h>
@@ -305,13 +305,13 @@ int msm_vidc_querybuf(struct msm_vidc_inst *inst, struct v4l2_buffer *b)
 			b->m.planes[0].m.mem_offset += 0;
 			break;
 		case INPUT_META_PORT:
-			b->m.planes[0].m.mem_offset += SRC_META_QUEUE_OFF_BASE;
+			b->m.offset += SRC_META_QUEUE_OFF_BASE;
 			break;
 		case OUTPUT_PORT:
 			b->m.planes[0].m.mem_offset += DST_QUEUE_OFF_BASE;
 			break;
 		case OUTPUT_META_PORT:
-			b->m.planes[0].m.mem_offset += DST_META_QUEUE_OFF_BASE;
+			b->m.offset += DST_META_QUEUE_OFF_BASE;
 			break;
 		default:
 			break;

--- a/vidc/src/msm_vidc_buffer.c
+++ b/vidc/src/msm_vidc_buffer.c
@@ -275,8 +275,9 @@ u32 msm_vidc_decoder_output_size(struct msm_vidc_inst *inst)
 	f = &inst->fmts[OUTPUT_PORT];
 	colorformat = v4l2_colorformat_to_driver(inst, f->fmt.pix_mp.pixelformat,
 		__func__);
-	size = video_buffer_size(colorformat, f->fmt.pix_mp.width,
-			f->fmt.pix_mp.height, true);
+	size = video_buffer_size(
+			colorformat, f->fmt.pix_mp.width, f->fmt.pix_mp.height,
+			inst->capabilities[CODED_FRAMES].value == CODED_FRAMES_INTERLACE);
 	return size;
 }
 
@@ -311,7 +312,8 @@ u32 msm_vidc_encoder_input_size(struct msm_vidc_inst *inst)
 		width = ALIGN(width, inst->capabilities[GRID_SIZE].value);
 		height = ALIGN(height, inst->capabilities[GRID_SIZE].value);
 	}
-	size = video_buffer_size(colorformat, width, height, true);
+	size = video_buffer_size(colorformat, width, height,
+			inst->capabilities[CODED_FRAMES].value == CODED_FRAMES_INTERLACE);
 	return size;
 }
 

--- a/vidc/src/msm_vidc_driver.c
+++ b/vidc/src/msm_vidc_driver.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2020-2022, The Linux Foundation. All rights reserved.
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
  */
 
 #include <linux/iommu.h>
@@ -802,6 +802,7 @@ int msm_vidc_qbuf_cache_operation(struct msm_vidc_inst *inst,
 			cache_type = MSM_MEM_CACHE_CLEAN_INVALIDATE;
 			break;
 		case MSM_VIDC_BUF_OUTPUT:
+		case MSM_VIDC_BUF_OUTPUT_META:
 			cache_type = MSM_MEM_CACHE_INVALIDATE;
 			break;
 		default:
@@ -841,6 +842,7 @@ int msm_vidc_dqbuf_cache_operation(struct msm_vidc_inst *inst,
 			skip = true;
 			break;
 		case MSM_VIDC_BUF_OUTPUT:
+		case MSM_VIDC_BUF_OUTPUT_META:
 			cache_type = MSM_MEM_CACHE_INVALIDATE;
 			break;
 		default:

--- a/vidc/src/msm_vidc_driver.c
+++ b/vidc/src/msm_vidc_driver.c
@@ -2102,6 +2102,8 @@ int msm_vidc_allocate_buffers(struct msm_vidc_inst *inst,
 	struct msm_vidc_buffer *buf = NULL;
 	struct msm_vidc_buffers *buffers;
 	struct msm_vidc_core *core;
+	struct msm_vidc_inst *i;
+	u32 count = 0;
 
 	core = inst->core;
 
@@ -2109,7 +2111,10 @@ int msm_vidc_allocate_buffers(struct msm_vidc_inst *inst,
 	if (!buffers)
 		return -EINVAL;
 
-	for (idx = 0; idx < num_buffers; idx++) {
+	list_for_each_entry(i, &buffers->list, list)
+		count++;
+
+	for (idx = 0; idx < num_buffers; idx++, count++) {
 		buf = msm_vidc_pool_alloc(inst, MSM_MEM_POOL_BUFFER);
 		if (!buf) {
 			i_vpr_e(inst, "%s: alloc failed\n", __func__);
@@ -2118,7 +2123,7 @@ int msm_vidc_allocate_buffers(struct msm_vidc_inst *inst,
 		INIT_LIST_HEAD(&buf->list);
 		list_add_tail(&buf->list, &buffers->list);
 		buf->type = buf_type;
-		buf->index = idx;
+		buf->index = count;
 		buf->region = call_mem_op(core, buffer_region, inst, buf_type);
 	}
 	i_vpr_h(inst, "%s: allocated %d buffers for type %s\n",

--- a/vidc/src/msm_vidc_vb2.c
+++ b/vidc/src/msm_vidc_vb2.c
@@ -715,7 +715,10 @@ int msm_vb2_queue_setup(struct vb2_queue *q,
 		*num_buffers = buffers->min_count + buffers->extra_count;
 		buffers->actual_count = *num_buffers;
 	} else {
-		buffers->actual_count += *num_buffers;
+		if (*num_buffers > (buffers->min_count + buffers->extra_count))
+			buffers->actual_count = *num_buffers;
+		else
+			buffers->actual_count += *num_buffers;
 	}
 	*num_planes = 1;
 

--- a/vidc/src/msm_vidc_vb2.c
+++ b/vidc/src/msm_vidc_vb2.c
@@ -695,7 +695,7 @@ int msm_vb2_queue_setup(struct vb2_queue *q,
 	if (!buffer_type)
 		return -EINVAL;
 
-	if (!is_state(inst, MSM_VIDC_STREAMING)) {
+	if (!is_state(inst, MSM_VIDC_STREAMING) && !(*num_buffers)) {
 		rc = msm_vidc_free_buffers(inst, buffer_type);
 		if (rc) {
 			i_vpr_e(inst, "%s: failed to free buffers, type %s\n",
@@ -708,11 +708,11 @@ int msm_vb2_queue_setup(struct vb2_queue *q,
 	if (!buffers)
 		return -EINVAL;
 
-	if (!is_state(inst, MSM_VIDC_STREAMING)) {
-		buffers->min_count = call_session_op(core, min_count, inst, buffer_type);
-		buffers->extra_count = call_session_op(core, extra_count, inst, buffer_type);
-		if (*num_buffers < buffers->min_count + buffers->extra_count)
-			*num_buffers = buffers->min_count + buffers->extra_count;
+	buffers->min_count = call_session_op(core, min_count, inst, buffer_type);
+	buffers->extra_count = call_session_op(core, extra_count, inst, buffer_type);
+
+	if ((vb2_get_num_buffers(q) + *num_buffers) < (buffers->min_count + buffers->extra_count)) {
+		*num_buffers = buffers->min_count + buffers->extra_count;
 		buffers->actual_count = *num_buffers;
 	} else {
 		buffers->actual_count += *num_buffers;

--- a/vidc/src/msm_vidc_vb2.c
+++ b/vidc/src/msm_vidc_vb2.c
@@ -18,6 +18,7 @@
 
 extern struct msm_vidc_core *g_core;
 
+static struct sg_table *vb2_dc_get_base_sgt(struct msm_vidc_buffer *buf);
 static void msm_vb2_vm_open(struct vm_area_struct *vma);
 static void msm_vb2_vm_close(struct vm_area_struct *vma);
 
@@ -65,9 +66,16 @@ void *msm_vb2_alloc(struct vb2_buffer *vb, struct device *dev,
 	struct msm_vidc_buffer *buf;
 	struct msm_vidc_inst *inst;
 	struct msm_vidc_core *core;
+	struct msm_vidc_dma_buf_info *dinfo;
 
-	if (!vb || !dev || !vb->vb2_queue)
+	dinfo = kzalloc(sizeof(*dinfo), GFP_KERNEL);
+	if (!dinfo)
+		return NULL;
+
+	if (!vb || !dev || !vb->vb2_queue) {
+		kfree(dinfo);
 		return ERR_PTR(-EINVAL);
+	}
 
 	inst = vb->vb2_queue->drv_priv;
 	inst = get_inst_ref(g_core, inst);
@@ -109,12 +117,20 @@ void *msm_vb2_alloc(struct vb2_buffer *vb, struct device *dev,
 		goto error;
 	}
 
-	buf->handler.refcount = &buf->refcount;
-	buf->handler.put = msm_vb2_put;
-	buf->handler.arg = buf;
-
-	refcount_set(&buf->refcount, 1);
-
+	buf->sg_table = vb2_dc_get_base_sgt(buf);
+	if (!buf->sg_table) {
+		i_vpr_e(inst, "Failed to build sg_table for buffer\n");
+		dma_free_attrs(cb->dev,
+			       buf->buffer_size,
+			       buf->kvaddr,
+			       buf->device_addr,
+			       buf->dma_attrs);
+		goto error;
+	}
+	dinfo->buf = buf;
+	refcount_set(&dinfo->refcount, 1);
+	d_vpr_l("%s: refcount set to %d\n", __func__, refcount_read(&dinfo->refcount));
+	buf->dma_buf_info = dinfo;
 	return buf;
 
 error:
@@ -187,6 +203,8 @@ void msm_vb2_vm_open(struct vm_area_struct *vma)
 		return;
 
 	refcount_inc(h->refcount);
+	d_vpr_l("%s: refcount incremented to %d dbuf: %pK\n", __func__,
+		refcount_read(h->refcount), h->arg);
 }
 
 void msm_vb2_vm_close(struct vm_area_struct *vma)
@@ -196,8 +214,9 @@ void msm_vb2_vm_close(struct vm_area_struct *vma)
 	if (IS_ERR_OR_NULL(h))
 		return;
 
-	if (h->put && h->arg)
-		h->put(h->arg);
+	refcount_dec(h->refcount);
+	d_vpr_l("%s: refcount decremented to %d dbuf: %pK\n", __func__,
+		refcount_read(h->refcount), h->arg);
 }
 
 static const struct vm_operations_struct msm_vb2_vm_dma_ops = {
@@ -208,7 +227,9 @@ static const struct vm_operations_struct msm_vb2_vm_dma_ops = {
 void msm_vb2_put(void *buf_priv)
 {
 	struct msm_vidc_buffer *buf = buf_priv;
+	struct msm_vidc_buffer *temp, *dummy;
 	enum msm_vidc_buffer_region region;
+	struct msm_vidc_buffers *buffers;
 	struct context_bank_info *cb;
 	struct msm_vidc_inst *inst;
 	struct msm_vidc_core *core;
@@ -222,9 +243,6 @@ void msm_vb2_put(void *buf_priv)
 
 	core = inst->core;
 
-	if (refcount_read(&buf->refcount) == 0)
-		return;
-
 	region = call_mem_op(core, buffer_region, inst, buf->type);
 	cb = msm_vidc_get_context_bank_for_region(inst->core, region);
 	if (!cb) {
@@ -232,52 +250,53 @@ void msm_vb2_put(void *buf_priv)
 		return;
 	}
 
-	if (!refcount_dec_and_test(&buf->refcount))
+	buffers = msm_vidc_get_buffers(inst, buf->type, __func__);
+	if (!buffers)
 		return;
 
-	if (buf->kvaddr && buf->device_addr) {
+	if (buf->dma_buf_info && refcount_dec_and_test(&buf->dma_buf_info->refcount)) {
+		i_vpr_h(inst, "%s: dma_free_atts: device_addr %llu, size %d\n",
+			__func__, buf->device_addr, buf->buffer_size);
 		dma_free_attrs(cb->dev, buf->buffer_size, buf->kvaddr,
 			       buf->device_addr, buf->dma_attrs);
-		buf->kvaddr = NULL;
-		buf->device_addr = 0x0;
+	} else {
+		d_vpr_l("%s: refcount decremented to %d dbuf: %pK\n", __func__,
+			refcount_read(&buf->dma_buf_info->refcount), buf->dmabuf);
 	}
-	put_inst(inst);
+
+	list_for_each_entry_safe(temp, dummy, &buffers->list, list) {
+		if (temp == buf) {
+			temp->dmabuf = NULL;
+			list_del_init(&temp->list);
+			msm_vidc_pool_free(inst, temp);
+			break;
+		}
+	}
 }
 
-int msm_vb2_mmap(void *buf_priv, struct vm_area_struct *vma)
+int msm_vb2_mmap(void *dma_buf, struct vm_area_struct *vma)
 {
-	struct msm_vidc_buffer *buf = buf_priv;
-	enum msm_vidc_buffer_region region;
-	struct context_bank_info *cb;
-	struct msm_vidc_inst *inst;
-	struct msm_vidc_core *core;
+	if (IS_ERR_OR_NULL(dma_buf))
+		return -EINVAL;
+
+	struct dma_buf *dbuf = dma_buf;
+	struct msm_vidc_dma_buf_info *dinfo = dbuf->priv;
 	int ret;
 
-	if (IS_ERR_OR_NULL(buf_priv))
+	if (!dinfo)
 		return -EINVAL;
-
-	inst = buf->inst;
-    if (!inst || !inst->core)
-		return -EINVAL;
-
-    core = inst->core;
-
-	region = call_mem_op(core, buffer_region, inst, buf->type);
-	cb = msm_vidc_get_context_bank_for_region(inst->core, region);
-	if (!cb) {
-		i_vpr_e(inst, "%s: failed to get context bank device\n", __func__);
-		return 0;
-	}
-
-	ret = dma_mmap_attrs(cb->dev, vma, buf->kvaddr, buf->device_addr,
-			     buf->buffer_size, buf->dma_attrs);
+	ret = dma_mmap_attrs(dinfo->dev, vma, dinfo->kvaddr, dinfo->device_addr,
+			     dinfo->buffer_size, dinfo->dma_attrs);
 	if (ret) {
-		i_vpr_e(inst, "Remapping memory failed, error: %d\n", ret);
+		d_vpr_e("Remapping memory failed, error: %d\n", ret);
 		return ret;
 	}
 
+	dinfo->handler.refcount = &dinfo->refcount;
+	dinfo->handler.arg = dbuf;
+
 	vm_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
-	vma->vm_private_data	= &buf->handler;
+	vma->vm_private_data	= &dinfo->handler;
 	vma->vm_ops		= &msm_vb2_vm_dma_ops;
 
 	vma->vm_ops->open(vma);
@@ -293,12 +312,19 @@ struct msm_vb2_attachment {
 static int msm_vb2_dmabuf_ops_attach(struct dma_buf *dbuf,
 				     struct dma_buf_attachment *dbuf_attach)
 {
+	if (IS_ERR_OR_NULL(dbuf))
+		return -EINVAL;
+
 	struct msm_vb2_attachment *attach;
 	unsigned int i;
 	struct scatterlist *rd, *wr;
 	struct sg_table *sgt;
-	struct msm_vidc_buffer *buf = dbuf->priv;
+	struct msm_vidc_dma_buf_info *dinfo = dbuf->priv;
 	int ret;
+
+	if (IS_ERR_OR_NULL(dinfo))
+		return -EINVAL;
+	struct msm_vidc_buffer *buf = dinfo->buf;
 
 	attach = kzalloc(sizeof(*attach), GFP_KERNEL);
 	if (!attach)
@@ -395,8 +421,27 @@ static void msm_vb2_dmabuf_ops_unmap(struct dma_buf_attachment *db_attach,
 
 static void msm_vb2_dmabuf_ops_release(struct dma_buf *dbuf)
 {
-	/* drop reference obtained in vb2_dc_get_dmabuf */
-	msm_vb2_put(dbuf->priv);
+	if (IS_ERR_OR_NULL(dbuf) || IS_ERR_OR_NULL(dbuf->priv))
+		return;
+
+	struct msm_vidc_dma_buf_info *dinfo = dbuf->priv;
+
+	if (refcount_read(&dinfo->refcount) == 0)
+		return;
+
+	if (!refcount_dec_and_test(&dinfo->refcount)) {
+		d_vpr_l("%s: refcount decremented to %d dbuf: %pK\n", __func__,
+			refcount_read(&dinfo->refcount), dbuf);
+		return;
+	}
+	d_vpr_h("%s: dma_free_atts: device_addr %llu, size %d\n",
+		__func__, dinfo->device_addr, dinfo->buffer_size);
+
+	dma_free_attrs(dinfo->dev, dinfo->buffer_size, dinfo->kvaddr,
+		       dinfo->device_addr, dinfo->dma_attrs);
+
+	kfree(dinfo);
+	dbuf->priv = NULL;
 }
 
 static int
@@ -416,7 +461,7 @@ msm_vb2_dmabuf_ops_end_cpu_access(struct dma_buf *dbuf,
 static int msm_vb2_dmabuf_ops_mmap(struct dma_buf *dbuf,
 	struct vm_area_struct *vma)
 {
-	return msm_vb2_mmap(dbuf->priv, vma);
+	return msm_vb2_mmap((void *)dbuf, vma);
 }
 
 static const struct dma_buf_ops msm_vb2_dmabuf_ops = {
@@ -471,12 +516,26 @@ struct dma_buf *msm_vb2_get_dmabuf(struct vb2_buffer *vb,
 						.owner = THIS_MODULE };
 	struct msm_vidc_buffer *buf = buf_priv;
 	struct msm_vidc_inst *inst = buf->inst;
+	enum msm_vidc_buffer_region region;
+	struct context_bank_info *cb;
+	struct msm_vidc_dma_buf_info *dinfo = buf->dma_buf_info;
 	struct dma_buf *dbuf;
 
+	region = call_mem_op((struct msm_vidc_core *)(inst->core), buffer_region, inst, buf->type);
+	cb = msm_vidc_get_context_bank_for_region(inst->core, region);
+	if (!cb) {
+		i_vpr_e(inst, "%s: failed to get context bank device\n", __func__);
+		return NULL;
+	}
+	dinfo->dev = cb->dev;
+	dinfo->buffer_size = buf->buffer_size;
+	dinfo->kvaddr = buf->kvaddr;
+	dinfo->device_addr = buf->device_addr;
+	dinfo->dma_attrs = buf->dma_attrs;
 	exp_info.ops = &msm_vb2_dmabuf_ops;
 	exp_info.size = buf->buffer_size;
 	exp_info.flags = flags;
-	exp_info.priv = buf;
+	exp_info.priv = dinfo;
 
 	if (!buf->sg_table)
 		buf->sg_table = vb2_dc_get_base_sgt(buf);
@@ -489,10 +548,10 @@ struct dma_buf *msm_vb2_get_dmabuf(struct vb2_buffer *vb,
 		i_vpr_e(inst, "%s: failed to export dma buf\n", __func__);
 		return NULL;
 	}
-
-	/* dmabuf keeps reference to vb2 buffer */
-	refcount_inc(&buf->refcount);
-
+	buf->dmabuf = dbuf;
+	refcount_inc(&dinfo->refcount);
+	d_vpr_l("%s: refcount incremented to %d dbuf: %pK\n", __func__,
+		refcount_read(&dinfo->refcount), dbuf);
 	return dbuf;
 }
 


### PR DESCRIPTION
This tag brings a number of updates for video driver:

- Implement VIDIOC_CREATE_BUFS to handle runtime buffer request from clients
- Introduce DMA buffer refcount handling for mmap usecase
- Update driver format to V4L2_PIX_FMT_QC10C for 10bit
- Optimize buffer size for interlace
- Miscellaneous fixes related to buffer count handling for seek and drc usecases