### PR TITLE
Add UAPI Checkers

### DIFF
--- a/.github/workflows/uapi-check.yml
+++ b/.github/workflows/uapi-check.yml
@@ -1,0 +1,31 @@
+name: UAPI and Driver Checks
+
+on:
+  pull_request:
+    # Optional: limit to main branch
+    branches: video.qclinux.0.0
+
+jobs:
+  uapi-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine base and head SHAs
+        id: shas
+        run: |
+          # PR base commit
+          echo "base_sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+          # PR head (current) commit
+          echo "head_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Run UAPI + driver checks
+        run: |
+          export BASE_SHA="${{ steps.shas.outputs.base_sha }}"
+          export HEAD_SHA="${{ steps.shas.outputs.head_sha }}"
+          ./ci/check-uapi-and-driver.sh
+

--- a/ci/check-uapi-and-driver.sh
+++ b/ci/check-uapi-and-driver.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -euo pipefail
+
+# BASE_SHA = commit to compare against (PR base)
+# HEAD_SHA = commit being tested (PR head)
+BASE_SHA="${BASE_SHA:-}"
+HEAD_SHA="${HEAD_SHA:-HEAD}"
+
+if [[ -z "$BASE_SHA" ]]; then
+    echo "ERROR: BASE_SHA is not set. Set BASE_SHA to the base commit to diff against."
+    exit 1
+fi
+
+echo "Running UAPI + driver checks between:"
+echo "  base = $BASE_SHA"
+echo "  head = $HEAD_SHA"
+echo
+
+changed_files=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA")
+if [[ -z "$changed_files" ]]; then
+    echo "No changed files; skipping checks."
+    exit 0
+fi
+
+exit_status=0
+
+###############################################################################
+# 1. UAPI header checks (v4l2_vidc_extensions.h)
+###############################################################################
+
+uapi_header="include/uapi/vidc/media/v4l2_vidc_extensions.h"
+
+if echo "$changed_files" | grep -q "^$uapi_header$"; then
+    echo "UAPI header changed: $uapi_header"
+    echo "Checking for removed struct/enums/defines that may break ABI ..."
+
+    pre_uapi=$(mktemp)
+    post_uapi=$(mktemp)
+
+    git show "$BASE_SHA:$uapi_header" > "$pre_uapi" 2>/dev/null || true
+    git show "$HEAD_SHA:$uapi_header" > "$post_uapi" 2>/dev/null || true
+
+    if [[ ! -s "$pre_uapi" ]]; then
+        echo "Note: UAPI header appears to be newly added; skipping ABI removal check."
+    else
+        removed_lines=$(diff -u "$pre_uapi" "$post_uapi" | grep '^-' | grep -v '^---' || true)
+
+        if echo "$removed_lines" \
+            | grep -E '^\-.*(struct|enum|#define|V4L2_.*|VIDC_.*)' >/dev/null; then
+            echo "ERROR: Potential ABI break in $uapi_header – definitions removed:"
+            echo "$removed_lines"
+            exit_status=1
+        fi
+    fi
+
+    rm -f "$pre_uapi" "$post_uapi"
+    echo
+fi
+
+###############################################################################
+# 2. Sysfs usage checks in modified C files
+###############################################################################
+
+echo "Checking for sysfs usage in modified C files ..."
+
+while read -r f; do
+    [[ -z "$f" ]] && continue
+    [[ "$f" != *.c ]] && continue
+
+    if grep -qE 'sysfs_create_file|device_create_file|sysfs_remove_file' "$f"; then
+        echo "ERROR: sysfs interface usage detected in modified file: $f"
+        echo "       Policy: avoid adding/modifying sysfs in this driver."
+        exit_status=1
+    fi
+done <<< "$changed_files"
+
+echo
+
+###############################################################################
+# 3. Optional: module_param checks
+###############################################################################
+
+echo "Checking module_param definitions ..."
+
+if echo "$changed_files" | grep -q '\.c$'; then
+    tmp_diff=$(mktemp)
+
+    git diff "$BASE_SHA" "$HEAD_SHA" -- '*.c' \
+        | grep -E '^[\+\-].*module_param' > "$tmp_diff" 2>/dev/null || true
+
+    if grep -E '^\-.*module_param' "$tmp_diff" >/dev/null; then
+        echo "ERROR: module_param removed/modified in diff:"
+        grep -E '^\-.*module_param' "$tmp_diff"
+        exit_status=1
+    fi
+
+    rm -f "$tmp_diff"
+fi
+
+echo
+if [[ "$exit_status" -ne 0 ]]; then
+    echo "UAPI/driver checks FAILED."
+else
+    echo "UAPI/driver checks PASSED."
+fi
+
+exit "$exit_status"


### PR DESCRIPTION
Add a GitHub Actions workflow and CI script to run UAPI and driver checks on every pull request.
The script watches changes in include/uapi/vidc/media/v4l2_vidc_extensions.h and driver sources under platform/, sources/, variant/, and vidc to prevent UAPI breaks and disallowed patterns.