### PR TITLE
media: iris: Cast iris_hfi_gen2_get_instance() allocation type

### DIFF
--- a/drivers/media/platform/qcom/iris/iris_hfi_gen2_command.c
+++ b/drivers/media/platform/qcom/iris/iris_hfi_gen2_command.c
@@ -1212,5 +1212,5 @@ void iris_hfi_gen2_command_ops_init(struct iris_core *core)
 
 struct iris_inst *iris_hfi_gen2_get_instance(void)
 {
-	return kzalloc(sizeof(struct iris_inst_hfi_gen2), GFP_KERNEL);
+	return (struct iris_inst *)kzalloc(sizeof(struct iris_inst_hfi_gen2), GFP_KERNEL);
 }


### PR DESCRIPTION
In preparation for making the kmalloc family of allocators type aware, we need to make sure that the returned type from the allocation matches the type of the variable being assigned. (Before, the allocator would always return "void *", which can be implicitly cast to any pointer type.)

The assigned type is "struct iris_inst *", but the returned type is "struct iris_inst_hfi_gen2 *". The allocation is intentionally larger as the first member of struct iris_inst_hfi_gen2 is struct iris_inst, so this is by design. Cast the allocation type to match the assignment.

Link: https://patch.msgid.link/20250426061526.work.106-kees@kernel.org