### PR TITLE
Update stale-issues.yaml

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -11,14 +11,15 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@v10
       with:
-        stale-issue-message: 'This issue has been marked as stale due to 60 days of inactivity.'
-        stale-pr-message: 'This pull request has been marked as stale due to 60 days of inactivity.'
+        stale-issue-message: '@qualcomm-linux/video-driver.triage This issue has been marked as stale due to 30 days of inactivity.'
+        stale-pr-message: '@qualcomm-linux/video-driver.triage This pull request has been marked as stale due to 30 days of inactivity.'
         exempt-issue-labels: bug,enhancement
         exempt-pr-labels: bug,enhancement
-        days-before-stale: 60
+        days-before-stale: 30
         days-before-close: -1
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true
+
         remove-pr-stale-when-updated: true


### PR DESCRIPTION
Summary:
This PR updates the stale-issues workflow with settings suggested
by OSSOps. These changes improve stale issue and PR management and
ensure the triage team is notified when items become inactive.

Changes included:
- Updated the workflow to use actions/stale@v10.
- Set the stale timeout to 30 days for issues and PRs.
- Added a team mention
- Disabled auto-close by setting days-before-close to -1.
- Enabled removal of the stale label when activity resumes.
- Kept existing bug and enhancement label exemptions.

Notes:
These settings follow OSSOps guidance. Please adjust any values as
needed for your workflow.