### PR TITLE
Align stale workflow with OSSOps recommendations

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -11,14 +11,15 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@v10
       with:
-        stale-issue-message: 'This issue has been marked as stale due to 60 days of inactivity.'
-        stale-pr-message: 'This pull request has been marked as stale due to 60 days of inactivity.'
+        stale-issue-message: '@qualcomm-linux/video-driver.triage This issue has been marked as stale due to 30 days of inactivity.'
+        stale-pr-message: '@qualcomm-linux/video-driver.triage This pull request has been marked as stale due to 30 days of inactivity.'
         exempt-issue-labels: bug,enhancement
         exempt-pr-labels: bug,enhancement
-        days-before-stale: 60
+        days-before-stale: 30
         days-before-close: -1
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true
+
         remove-pr-stale-when-updated: true


### PR DESCRIPTION
This PR updates the stale-issues GitHub workflow to follow OSSOps recommended settings. These changes improve the handling of stale issues and PRs, ensure maintainers are notified when items become stale, and prevent premature closure of active work.

Updates include:

Setting a 30-day threshold for staleness.
Notifying maintainers when issues/PRs become stale.
Preventing automatic closure of stale items.
Remove exemption labels for issues and PRs, as exemptions are only useful when auto‑closing is enabled, and auto‑closing is intentionally disabled.

These changes align this repository's automation behavior with Qualcomm's open-source best practices.
Please feel free to update or tune any of the workflow settings if there are project-specific requirements or preferred defaults.