### PR TITLE
video: driver: add alignment for encoder input resolution

### DIFF
--- a/driver/vidc/src/msm_venc.c
+++ b/driver/vidc/src/msm_venc.c
@@ -1257,8 +1257,8 @@ static int msm_venc_s_fmt_input(struct msm_vidc_inst *inst, struct v4l2_format *
 
 	fmt = &inst->fmts[INPUT_PORT];
 	fmt->type = INPUT_MPLANE;
-	fmt->fmt.pix_mp.width = width;
-	fmt->fmt.pix_mp.height = height;
+	fmt->fmt.pix_mp.width = video_y_stride_pix(pix_fmt, width);
+	fmt->fmt.pix_mp.height = video_y_scanlines(pix_fmt, height);
 	fmt->fmt.pix_mp.num_planes = 1;
 	fmt->fmt.pix_mp.pixelformat = f->fmt.pix_mp.pixelformat;
 	fmt->fmt.pix_mp.plane_fmt[0].bytesperline = bytesperline;


### PR DESCRIPTION
Align encoder input resolution to fix green lines at the bottom.