### PR TITLE
video: driver: fix RO buffer DMA memory leak on teardown and fix raw buffer size for interlace handling

### DIFF
--- a/driver/vidc/src/msm_vidc_buffer.c
+++ b/driver/vidc/src/msm_vidc_buffer.c
@@ -282,8 +282,8 @@ u32 msm_vidc_decoder_output_size(struct msm_vidc_inst *inst)
 	f = &inst->fmts[OUTPUT_PORT];
 	colorformat = v4l2_colorformat_to_driver(inst, f->fmt.pix_mp.pixelformat,
 		__func__);
-	size = video_buffer_size(colorformat, f->fmt.pix_mp.width,
-			f->fmt.pix_mp.height, true);
+	size = video_buffer_size(colorformat, f->fmt.pix_mp.width, f->fmt.pix_mp.height,
+				 inst->capabilities[CODED_FRAMES].value == CODED_FRAMES_INTERLACE);
 	return size;
 }
 
@@ -313,12 +313,13 @@ u32 msm_vidc_encoder_input_size(struct msm_vidc_inst *inst)
 	width = f->fmt.pix_mp.width;
 	height = f->fmt.pix_mp.height;
 	colorformat = v4l2_colorformat_to_driver(inst, f->fmt.pix_mp.pixelformat,
-		__func__);
+						 __func__);
 	if (is_image_session(inst)) {
 		width = ALIGN(width, inst->capabilities[GRID_SIZE].value);
 		height = ALIGN(height, inst->capabilities[GRID_SIZE].value);
 	}
-	size = video_buffer_size(colorformat, width, height, true);
+	size = video_buffer_size(colorformat, width, height,
+				 inst->capabilities[CODED_FRAMES].value == CODED_FRAMES_INTERLACE);
 	return size;
 }
 

--- a/driver/vidc/src/msm_vidc_driver.c
+++ b/driver/vidc/src/msm_vidc_driver.c
@@ -5246,6 +5246,9 @@ int msm_vidc_flush_read_only_buffers(struct msm_vidc_inst *inst,
 		if (ro_buf->attach && ro_buf->dmabuf)
 			call_mem_op(core, dma_buf_detach, core,
 				ro_buf->dmabuf, ro_buf->attach);
+		if (ro_buf->kvaddr && ro_buf->device_addr)
+			dma_free_attrs(&core->pdev->dev, ro_buf->buffer_size,
+					ro_buf->kvaddr, ro_buf->device_addr, ro_buf->dma_attrs);
 		if (ro_buf->dbuf_get)
 			call_mem_op(core, dma_buf_put, inst, ro_buf->dmabuf);
 		ro_buf->attach = NULL;
@@ -5324,10 +5327,9 @@ void msm_vidc_destroy_buffers(struct msm_vidc_inst *inst)
 				buf->attach, buf->sg_table);
 		if (buf->attach && buf->dmabuf)
 			call_mem_op(core, dma_buf_detach, core, buf->dmabuf, buf->attach);
-		if (buf->kvaddr && buf->device_addr && refcount_read(&buf->refcount) > 0)
-			i_vpr_e(inst,
-				"%s: destroy ro buffer with Non-Zero refcount %d, daddr 0x%llx\n",
-					__func__, refcount_read(&buf->refcount), buf->device_addr);
+		if (buf->kvaddr && buf->device_addr)
+			dma_free_attrs(&core->pdev->dev, buf->buffer_size,
+					buf->kvaddr, buf->device_addr, buf->dma_attrs);
 		if (buf->dbuf_get)
 			call_mem_op(core, dma_buf_put, inst, buf->dmabuf);
 		list_del_init(&buf->list);
@@ -5345,10 +5347,10 @@ void msm_vidc_destroy_buffers(struct msm_vidc_inst *inst)
 					buf->attach, buf->sg_table);
 			if (buf->attach && buf->dmabuf)
 				call_mem_op(core, dma_buf_detach, core, buf->dmabuf, buf->attach);
-			if (buf->kvaddr && buf->device_addr && refcount_read(&buf->refcount) > 0)
-				i_vpr_e(inst,
-					"%s: destroying ext buffer, refcount %d, daddr 0x%llx\n",
-					__func__, refcount_read(&buf->refcount), buf->device_addr);
+			if (buf->kvaddr && buf->device_addr)
+				dma_free_attrs(&core->pdev->dev, buf->buffer_size,
+						buf->kvaddr, buf->device_addr, buf->dma_attrs);
+
 			if (buf->dbuf_get) {
 				print_vidc_buffer(VIDC_ERR, "err ", "destroying: put dmabuf",
 						  inst, buf);

--- a/driver/vidc/src/msm_vidc_vb2.c
+++ b/driver/vidc/src/msm_vidc_vb2.c
@@ -267,9 +267,22 @@ void msm_vb2_put(void *buf_priv)
 	if (IS_ERR_OR_NULL(buf_priv))
 		return;
 
+	if (refcount_read(&buf->refcount) == 0)
+		return;
+
 	inst = buf->inst;
 	if (!inst || !inst->core)
 		return;
+
+	if (is_decode_session(inst) && is_output_buffer(buf->type)) {
+		list_for_each_entry_safe(temp, dummy, &inst->buffers.read_only.list, list) {
+			if (temp->device_addr != buf->device_addr)
+				continue;
+			buf->kvaddr = NULL;
+			buf->device_addr = 0x0;
+			return;
+		}
+	}
 
 	core = inst->core;
 

--- a/driver/vidc/src/venus_hfi_response.c
+++ b/driver/vidc/src/venus_hfi_response.c
@@ -2048,6 +2048,9 @@ static int handle_property_with_payload(struct msm_vidc_inst *inst,
 		break;
 	case HFI_PROP_CODED_FRAMES:
 		inst->subcr_params[port].coded_frames = payload_ptr[0];
+		msm_vidc_update_cap_value(inst, CODED_FRAMES,
+					  inst->subcr_params[port].coded_frames,
+					  __func__);
 		break;
 	case HFI_PROP_BUFFER_FW_MIN_OUTPUT_COUNT:
 		inst->subcr_params[port].fw_min_count = payload_ptr[0];


### PR DESCRIPTION
Ensure RO and external buffers are properly freed with dma_free_attrs()
during flush and destroy paths instead of only logging non-zero refcounts.

Also guard msm_vb2_put() against zero refcount buffers and avoid freeing
DMA memory for decode output buffers that are tracked as read-only, to
prevent double free and memory corruption.

Fix raw buffer size calculation by deferring interlace handling to firmware events.