### PR TITLE
video: driver: Add support for 32 concurrent session on lemans

### DIFF
--- a/driver/platform/common/inc/msm_vidc_platform.h
+++ b/driver/platform/common/inc/msm_vidc_platform.h
@@ -304,7 +304,7 @@ struct msm_vidc_platform_data {
 	unsigned int dec_output_prop_size_mpeg2;
 	const u32  *msm_vidc_ssr_type;
 	unsigned int msm_vidc_ssr_type_size;
-
+	int (*init_cb_devs)(struct msm_vidc_core *core);
 };
 
 struct msm_vidc_platform {

--- a/driver/platform/lemans/src/lemans.c
+++ b/driver/platform/lemans/src/lemans.c
@@ -1868,12 +1868,13 @@ static const struct clk_rst_table lemans_clk_reset_table[] = {
 
 /* name, start, size, secure, dma_coherant, region, dma_mask */
 const struct context_bank_table lemans_context_bank_table[] = {
-	{"qcom,sa8775p-iris", 0x25800000, 0xba800000, 0, 1,     MSM_VIDC_NON_SECURE |
-								MSM_VIDC_NON_SECURE_BITSTREAM |
-								MSM_VIDC_NON_SECURE_PIXEL,       0},
-	{"qcom,sa8775p-iris", 0x01000000, 0x24800000, 1, 0,     MSM_VIDC_SECURE_NONPIXEL,        0},
+	{"qcom,vidc,cb-ns", 0x25800000, 0xba800000, 0, 1,
+				MSM_VIDC_NON_SECURE | MSM_VIDC_NON_SECURE_BITSTREAM,	0},
+	{"qcom,vidc,cb-ns-pxl", 0x00100000, 0xdff00000, 0, 1,
+				MSM_VIDC_NON_SECURE_PIXEL,				0},
+	{"qcom,vidc,cb-sec-non-pxl", 0x01400000, 0x24400000, 1, 0,
+				MSM_VIDC_SECURE_NONPIXEL,				0},
 };
-
 
 /* register, value, mask */
 static const struct reg_preset_table lemans_reg_preset_table[] = {

--- a/driver/platform/lemans/src/lemans.c
+++ b/driver/platform/lemans/src/lemans.c
@@ -18,6 +18,7 @@
 #include "hfi_command.h"
 #include "venus_hfi.h"
 #include "msm_vidc_driver.h"
+#include "resources.h"
 
 #define DEFAULT_VIDEO_CONCEAL_COLOR_BLACK 0x8000800010
 #define MAX_BASE_LAYER_PRIORITY_ID 63
@@ -1984,6 +1985,46 @@ static const u32 lemans_msm_vidc_ssr_type[] = {
 	HFI_SSR_TYPE_SW_ERR_FATAL,
 };
 
+/*
+ * msm_vidc_lemans_init_cb_devs - lemans-specific iommu-map CB initializer.
+ *
+ * Creates a child platform device for each non-secure context bank and
+ * configures it with the hardcoded fid from the iommu-map DT property:
+ *   qcom,vidc,cb-ns     (NON_SECURE | NON_SECURE_BITSTREAM) -> fid 0
+ *   qcom,vidc,cb-ns-pxl (NON_SECURE_PIXEL)                  -> fid 1
+ */
+static int msm_vidc_lemans_init_cb_devs(struct msm_vidc_core *core)
+{
+	/* Hardcoded fid per CB name for lemans iommu-map */
+	static const struct {
+		const char *cb_name;
+		u32 fid;
+	} lemans_cb_fid[] = {
+		{ "qcom,vidc,cb-ns",     0 },
+		{ "qcom,vidc,cb-ns-pxl", 1 },
+	};
+	struct context_bank_info *cb;
+	int i, rc;
+
+	venus_hfi_for_each_context_bank(core, cb) {
+		for (i = 0; i < ARRAY_SIZE(lemans_cb_fid); i++) {
+			if (strcmp(cb->name, lemans_cb_fid[i].cb_name))
+				continue;
+
+			rc = msm_vidc_create_child_device_and_map(core, cb,
+								  lemans_cb_fid[i].fid);
+			if (rc) {
+				d_vpr_e("%s: failed to create child device for %s rc %d\n",
+					__func__, cb->name, rc);
+				return rc;
+			}
+			break;
+		}
+	}
+
+	return 0;
+}
+
 static const struct msm_vidc_platform_data lemans_data = {
 	/* resources dependent on other module */
 	.bw_tbl = lemans_bw_table,
@@ -2047,6 +2088,7 @@ static const struct msm_vidc_platform_data lemans_data = {
 	.dec_output_prop_size_av1 = ARRAY_SIZE(lemans_vdec_output_properties_av1),
 	.msm_vidc_ssr_type = lemans_msm_vidc_ssr_type,
 	.msm_vidc_ssr_type_size = ARRAY_SIZE(lemans_msm_vidc_ssr_type),
+	.init_cb_devs = msm_vidc_lemans_init_cb_devs,
 };
 
 static int msm_vidc_lemans_check_ddr_type(void)

--- a/driver/vidc/inc/msm_vidc_core.h
+++ b/driver/vidc/inc/msm_vidc_core.h
@@ -148,6 +148,7 @@ struct msm_vidc_core {
 	/* hw_version: distinguish chip versions: v1, v2 */
 	enum msm_vidc_hw_version               hw_version;
 	int                                    cb_count;
+	int                                    cb_virtual_count;
 };
 
 #endif // _MSM_VIDC_CORE_H_

--- a/driver/vidc/inc/msm_vidc_driver.h
+++ b/driver/vidc/inc/msm_vidc_driver.h
@@ -591,6 +591,9 @@ void msm_vidc_print_core_info(struct msm_vidc_core *core);
 int msm_vidc_smmu_fault_handler(struct iommu_domain *domain,
 				struct device *dev, unsigned long iova,
 				int flags, void *data);
+struct context_bank_info;
+int msm_vidc_create_child_device_and_map(struct msm_vidc_core *core,
+					 struct context_bank_info *cb, u32 fid);
 int msm_vidc_trigger_ssr(struct msm_vidc_core *core,
 			 u64 trigger_ssr_val);
 void msm_vidc_ssr_handler(struct work_struct *work);

--- a/driver/vidc/inc/msm_vidc_internal.h
+++ b/driver/vidc/inc/msm_vidc_internal.h
@@ -102,7 +102,7 @@ enum msm_vidc_log_encode_mode {
 #define MAXIMUM_VP9_FPS   60
 #define NRT_PRIORITY_OFFSET        2
 #define RT_DEC_DOWN_PRORITY_OFFSET 1
-#define MAX_SUPPORTED_INSTANCES  16
+#define MAX_SUPPORTED_INSTANCES  32
 #define DEFAULT_BSE_VPP_DELAY    2
 #define MAX_CAP_PARENTS          20
 #define MAX_CAP_CHILDREN         25

--- a/driver/vidc/src/msm_vidc_probe.c
+++ b/driver/vidc/src/msm_vidc_probe.c
@@ -5,6 +5,7 @@
  */
 
 #include <linux/of_platform.h>
+#include <linux/of_device.h>
 #include <linux/component.h>
 #include <linux/debugfs.h>
 #include <linux/iommu.h>
@@ -638,6 +639,8 @@ static void msm_vidc_component_unbind(struct device *dev,
 #endif
 }
 
+static void msm_vidc_destroy_cb_devices(struct msm_vidc_core *core);
+
 static int msm_vidc_component_master_bind(struct device *dev)
 {
 	struct msm_vidc_core *core = dev_get_drvdata(dev);
@@ -708,7 +711,8 @@ static void msm_vidc_component_master_unbind(struct device *dev)
 	msm_vidc_deinitialize_media(core);
 	if (core->cb_count)
 		component_unbind_all(dev, core);
-
+	else if (core->cb_virtual_count)
+		msm_vidc_destroy_cb_devices(core);
 
 	d_vpr_h("%s(): successful\n", __func__);
 }
@@ -831,27 +835,123 @@ static struct notifier_block msm_vidc_reboot_nb = {
 };
 #endif
 
+int msm_vidc_create_child_device_and_map(struct msm_vidc_core *core,
+					 struct context_bank_info *cb, u32 fid)
+{
+	struct platform_device *pdev;
+	int ret;
+
+	pdev = platform_device_alloc(cb->name, 0);
+	if (!pdev)
+		return -ENOMEM;
+
+	pdev->dev.parent = &core->pdev->dev;
+
+	ret = platform_device_add(pdev);
+	if (ret) {
+		platform_device_put(pdev);
+		return ret;
+	}
+
+	ret = of_dma_configure_id(&pdev->dev, core->pdev->dev.of_node,
+				  true, &fid);
+	if (ret) {
+		d_vpr_e("%s: of_dma_configure_id failed for %s fid %u ret %d\n",
+			__func__, cb->name, fid, ret);
+		goto error_unregister;
+	}
+
+	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_MASK);
+	if (ret) {
+		d_vpr_e("%s: dma_set_mask_and_coherent failed for %s ret %d\n",
+			__func__, cb->name, ret);
+		goto error_unregister;
+	}
+
+	cb->dev = &pdev->dev;
+	core->cb_virtual_count++;
+
+	d_vpr_h("%s: created child device %s fid %u\n", __func__, cb->name, fid);
+	return 0;
+
+error_unregister:
+	platform_device_unregister(pdev);
+	return ret;
+}
+
+static void msm_vidc_destroy_cb_devices(struct msm_vidc_core *core)
+{
+	struct context_bank_info *cb;
+
+	if (!core->cb_virtual_count)
+		return;
+
+	venus_hfi_for_each_context_bank(core, cb) {
+		if (!cb->dev)
+			continue;
+		platform_device_unregister(to_platform_device(cb->dev));
+		cb->dev = NULL;
+		cb->domain = NULL;
+		if (!--core->cb_virtual_count)
+			break;
+	}
+}
+
 static int msm_vidc_probe_without_context_bank(struct platform_device *pdev,
 					       struct msm_vidc_core *core)
 {
 	int rc = 0;
 	struct context_bank_info *cb = NULL;
 
-	venus_hfi_for_each_context_bank(core, cb) {
-		cb->dev = &pdev->dev;
-		cb->domain = iommu_get_domain_for_dev(cb->dev);
-		if (!cb->domain) {
-			d_vpr_e("%s: Failed to get iommu domain for %s\n",
-				__func__, dev_name(cb->dev));
-			return -EIO;
-		}
+	if (core->platform->data.init_cb_devs &&
+	    of_find_property(pdev->dev.of_node, "iommu-map", NULL)) {
 		/*
-		 * Set fault handler only once per domain to avoid kernel warnings.
-		 * Check if handler is NULL before registering to avoid duplicate warnings.
+		 * iommu-map present: platform provides init_cb_devs to create
+		 * a child platform device for each CB with a valid fid.
 		 */
-		if (!cb->domain->handler) {
-			iommu_set_fault_handler(cb->domain,
-						msm_vidc_smmu_fault_handler, (void *)core);
+		rc = core->platform->data.init_cb_devs(core);
+		if (rc) {
+			d_vpr_e("%s: init_cb_devs failed rc %d\n", __func__, rc);
+			return rc;
+		}
+
+		/* Set up iommu domain and fault handler for each mapped CB */
+		venus_hfi_for_each_context_bank(core, cb) {
+			if (!cb->dev)
+				continue;
+
+			cb->domain = iommu_get_domain_for_dev(cb->dev);
+			if (!cb->domain) {
+				d_vpr_e("%s: Failed to get iommu domain for %s\n",
+					__func__, dev_name(cb->dev));
+				rc = -EIO;
+				break;
+			}
+
+			if (!cb->domain->handler)
+				iommu_set_fault_handler(cb->domain,
+							msm_vidc_smmu_fault_handler,
+							(void *)core);
+		}
+		if (rc) {
+			msm_vidc_destroy_cb_devices(core);
+			return rc;
+		}
+	} else {
+		/* Legacy: map all CBs to the main platform device */
+		venus_hfi_for_each_context_bank(core, cb) {
+			cb->dev = &pdev->dev;
+			cb->domain = iommu_get_domain_for_dev(cb->dev);
+			if (!cb->domain) {
+				d_vpr_e("%s: Failed to get iommu domain for %s\n",
+					__func__, dev_name(cb->dev));
+				return -EIO;
+			}
+			if (!cb->domain->handler) {
+				iommu_set_fault_handler(cb->domain,
+							msm_vidc_smmu_fault_handler,
+							(void *)core);
+			}
 		}
 	}
 
@@ -861,6 +961,7 @@ static int msm_vidc_probe_without_context_bank(struct platform_device *pdev,
 	rc = msm_vidc_component_master_bind(&pdev->dev);
 	if (rc < 0) {
 		d_vpr_e("%s: component master bind failed\n", __func__);
+		msm_vidc_destroy_cb_devices(core);
 		return rc;
 	}
 	d_vpr_h("%s(): successful\n", __func__);

--- a/driver/vidc/src/msm_vidc_probe.c
+++ b/driver/vidc/src/msm_vidc_probe.c
@@ -567,8 +567,14 @@ static int msm_vidc_setup_context_bank(struct msm_vidc_core *core,
 	dma_set_max_seg_size(dev, (unsigned int)DMA_BIT_MASK(32));
 	dma_set_seg_boundary(dev, (unsigned long)DMA_BIT_MASK(64));
 
-	iommu_set_fault_handler(cb->domain,
-		msm_vidc_smmu_fault_handler, (void *)core);
+	/*
+	 * Set fault handler only once per domain to avoid kernel warnings.
+	 * Check if handler is NULL before registering to avoid duplicate warnings.
+	 */
+	if (!cb->domain->handler) {
+		iommu_set_fault_handler(cb->domain,
+					msm_vidc_smmu_fault_handler, (void *)core);
+	}
 
 	d_vpr_h(
 		"%s: name %s addr start %x size %x secure %d dma_coherant %d "
@@ -839,7 +845,14 @@ static int msm_vidc_probe_without_context_bank(struct platform_device *pdev,
 				__func__, dev_name(cb->dev));
 			return -EIO;
 		}
-		iommu_set_fault_handler(cb->domain, msm_vidc_smmu_fault_handler, (void *)core);
+		/*
+		 * Set fault handler only once per domain to avoid kernel warnings.
+		 * Check if handler is NULL before registering to avoid duplicate warnings.
+		 */
+		if (!cb->domain->handler) {
+			iommu_set_fault_handler(cb->domain,
+						msm_vidc_smmu_fault_handler, (void *)core);
+		}
 	}
 
 	dma_set_mask_and_coherent(&pdev->dev, DMA_MASK);


### PR DESCRIPTION
Add iommu-map support for context banks, thereby adding more IOVA needed to support 32 concurrency