### PR TITLE
video: driver: Add PAS context for KVM with Linux-managed IOMMU

### DIFF
--- a/driver/vidc/inc/firmware.h
+++ b/driver/vidc/inc/firmware.h
@@ -14,5 +14,7 @@ int fw_unload(struct msm_vidc_core *core);
 int fw_suspend(struct msm_vidc_core *core);
 int fw_resume(struct msm_vidc_core *core);
 void fw_coredump(struct msm_vidc_core *core);
+int fw_init(struct msm_vidc_core *core);
+void fw_deinit(struct msm_vidc_core *core);
 
 #endif

--- a/driver/vidc/inc/msm_vidc_core.h
+++ b/driver/vidc/inc/msm_vidc_core.h
@@ -145,6 +145,11 @@ struct msm_vidc_core {
 	u32                                    packet_id;
 	u32                                    sys_init_id;
 	struct msm_vidc_synx_fence_data        synx_fence_data;
+	struct video_firmware {
+		struct device *dev;
+		struct qcom_scm_pas_context *ctx;
+		struct iommu_domain *iommu_domain;
+	} fw;
 	/* hw_version: distinguish chip versions: v1, v2 */
 	enum msm_vidc_hw_version               hw_version;
 	int                                    cb_count;

--- a/driver/vidc/src/firmware.c
+++ b/driver/vidc/src/firmware.c
@@ -5,6 +5,9 @@
 #include <linux/types.h>
 #include <linux/list.h>
 #include <linux/of_address.h>
+#include <linux/of_device.h>
+#include <linux/platform_device.h>
+#include <linux/iommu.h>
 #include <linux/version.h>
 #if (KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE)
 #include <linux/firmware/qcom/qcom_scm.h>
@@ -30,6 +33,57 @@ enum tzbsp_video_state {
 	TZBSP_VIDEO_STATE_RESUME = 1,
 	TZBSP_VIDEO_STATE_RESTORE_THRESHOLD = 2,
 };
+
+static int fw_pas_load(struct msm_vidc_core *core,
+			const struct firmware *firmware,
+			const char *fw_name,
+			phys_addr_t phys, size_t res_size)
+{
+	struct device *dev = core->fw.dev ?: &core->pdev->dev;
+	int pas_id = core->platform->data.pas_id;
+	struct qcom_scm_pas_context *ctx;
+	int rc = 0;
+
+	ctx = devm_qcom_scm_pas_context_alloc(dev, pas_id, phys, res_size);
+	if (IS_ERR(ctx)) {
+		d_vpr_e("%s: failed to initialize PAS context\n", __func__);
+		return PTR_ERR(ctx);
+	}
+
+	ctx->use_tzmem = core->fw.dev;
+	rc = qcom_mdt_pas_load(ctx, firmware, fw_name, NULL);
+	if (rc) {
+		d_vpr_e("%s: error %d pas-load fw \"%s\"\n", __func__, rc, fw_name);
+		goto metadata_release;
+	}
+
+	if (core->fw.iommu_domain) {
+		rc = iommu_map(core->fw.iommu_domain, 0, phys, res_size,
+				IOMMU_READ | IOMMU_WRITE | IOMMU_PRIV, GFP_KERNEL);
+		if (rc) {
+			d_vpr_e("%s: iommu_map failed rc=%d\n", __func__, rc);
+			goto metadata_release;
+		}
+	}
+
+	rc = qcom_scm_pas_prepare_and_auth_reset(ctx);
+	if (rc) {
+		d_vpr_e("%s: auth+reset failed rc=%d fw \"%s\"\n", __func__, rc, fw_name);
+		goto err_iommu_unmap;
+	}
+
+	qcom_scm_pas_metadata_release(ctx);
+	core->fw.ctx = ctx;
+	d_vpr_h("%s: PAS setup completed successfully\n", __func__);
+	return 0;
+
+err_iommu_unmap:
+	if (core->fw.iommu_domain)
+		iommu_unmap(core->fw.iommu_domain, 0, res_size);
+metadata_release:
+	qcom_scm_pas_metadata_release(ctx);
+	return rc;
+}
 
 static int __load_fw_to_memory(struct platform_device *pdev,
 			const char *firmware_name)
@@ -95,33 +149,19 @@ static int __load_fw_to_memory(struct platform_device *pdev,
 		goto exit;
 	}
 
-	virt = memremap(phys, res_size, MEMREMAP_WC);
-	if (!virt) {
-		d_vpr_e("%s: failed to remap fw memory phys %pa[p]\n",
-			__func__, &phys);
-		return -ENOMEM;
-	}
-
-	/* prevent system suspend during fw_load */
 	pm_stay_awake(pdev->dev.parent);
-	rc = qcom_mdt_load(&pdev->dev, firmware, firmware_name,
-			   pas_id, virt, phys, res_size, NULL);
+	rc = fw_pas_load(core, firmware, firmware_name, phys, res_size);
 	pm_relax(pdev->dev.parent);
-	if (rc) {
-		d_vpr_e("%s: error %d loading fw \"%s\"\n",
-			__func__, rc, firmware_name);
+	if (rc)
 		goto exit;
-	}
-	rc = qcom_scm_pas_auth_and_reset(pas_id);
-	if (rc) {
-		d_vpr_e("%s: error %d authenticating fw \"%s\"\n",
-			__func__, rc, firmware_name);
-		goto exit;
-	}
 
 	/* Enabling FW memory-region dump during Kernel panic */
-	call_md_op(core, md_dump_fw_region, core, "vidc_core", virt, phys, res_size);
-	memunmap(virt);
+	virt = memremap(phys, res_size, MEMREMAP_WC);
+	if (virt) {
+		call_md_op(core, md_dump_fw_region, core, "vidc_core", virt, phys, res_size);
+		memunmap(virt);
+	}
+
 	release_firmware(firmware);
 	d_vpr_h("%s: firmware \"%s\" loaded successfully\n",
 		__func__, firmware_name);
@@ -129,8 +169,6 @@ static int __load_fw_to_memory(struct platform_device *pdev,
 	return pas_id;
 
 exit:
-	if (virt)
-		memunmap(virt);
 	if (firmware)
 		release_firmware(firmware);
 
@@ -166,6 +204,9 @@ int fw_load(struct msm_vidc_core *core)
 fail_scm_mem_protect:
 	if (core->resource->fw_cookie)
 		qcom_scm_pas_shutdown(core->resource->fw_cookie);
+	if (core->fw.iommu_domain && core->fw.ctx)
+		iommu_unmap(core->fw.iommu_domain, 0, core->fw.ctx->mem_size);
+	core->fw.ctx = NULL;
 	core->resource->fw_cookie = 0;
 	return rc;
 }
@@ -179,6 +220,9 @@ int fw_unload(struct msm_vidc_core *core)
 
 	d_vpr_h("%s: unloading video firmware\n", __func__);
 	ret = qcom_scm_pas_shutdown(core->resource->fw_cookie);
+	if (core->fw.iommu_domain && core->fw.ctx)
+		iommu_unmap(core->fw.iommu_domain, 0, core->fw.ctx->mem_size);
+	core->fw.ctx = NULL;
 	if (ret)
 		d_vpr_e("Firmware unload failed rc=%d\n", ret);
 
@@ -195,6 +239,67 @@ int fw_suspend(struct msm_vidc_core *core)
 int fw_resume(struct msm_vidc_core *core)
 {
 	return qcom_scm_set_remote_state(TZBSP_VIDEO_STATE_RESUME, 0);
+}
+
+int fw_init(struct msm_vidc_core *core)
+{
+	struct platform_device_info info;
+	struct platform_device *pdev;
+	struct iommu_domain *dom;
+	struct device_node *np;
+	int ret;
+
+	np = of_get_child_by_name(core->pdev->dev.of_node, "video-firmware");
+	if (!np)
+		return 0;
+
+	memset(&info, 0, sizeof(info));
+	info.fwnode = &np->fwnode;
+	info.parent = &core->pdev->dev;
+	info.name = np->name;
+	info.dma_mask = DMA_BIT_MASK(32);
+
+	pdev = platform_device_register_full(&info);
+	if (IS_ERR(pdev)) {
+		of_node_put(np);
+		return PTR_ERR(pdev);
+	}
+	pdev->dev.of_node = np;
+
+	ret = of_dma_configure(&pdev->dev, np, true);
+	if (ret) {
+		d_vpr_e("of_dma_configure failed rc=%d\n", ret);
+		goto err_unregister;
+	}
+
+	core->fw.dev = &pdev->dev;
+	dom = iommu_get_domain_for_dev(core->fw.dev);
+	if (!dom) {
+		d_vpr_e("Failed to get iommu domain\n");
+		ret = -EINVAL;
+		goto err_unset_fw_dev;
+	}
+
+	core->fw.iommu_domain = dom;
+	of_node_put(np);
+	return 0;
+
+err_unset_fw_dev:
+	core->fw.dev = NULL;
+err_unregister:
+	platform_device_unregister(pdev);
+	of_node_put(np);
+	return ret;
+}
+
+void fw_deinit(struct msm_vidc_core *core)
+{
+	if (!core->fw.dev)
+		return;
+
+	core->fw.iommu_domain = NULL;
+	platform_device_unregister(to_platform_device(core->fw.dev));
+	core->fw.dev = NULL;
 }
 
 void fw_coredump(struct msm_vidc_core *core)

--- a/driver/vidc/src/venus_hfi.c
+++ b/driver/vidc/src/venus_hfi.c
@@ -828,6 +828,12 @@ static int __load_fw(struct msm_vidc_core *core)
 		goto fail_power;
 	}
 
+	rc = fw_init(core);
+	if (rc) {
+		d_vpr_e("%s: fw_init failed rc=%d\n", __func__, rc);
+		goto fail_fw_init;
+	}
+
 	rc = fw_load(core);
 	if (rc)
 		goto fail_load_fw;
@@ -837,6 +843,8 @@ static int __load_fw(struct msm_vidc_core *core)
 	return rc;
 
 fail_load_fw:
+	fw_deinit(core);
+fail_fw_init:
 	__venus_power_off(core);
 fail_power:
 	trace_msm_v4l2_vidc_fw_load("END");
@@ -852,6 +860,7 @@ static void __unload_fw(struct msm_vidc_core *core)
 	__venus_power_off(core);
 	fw_unload(core);
 
+	fw_deinit(core);
 	/* clear all substates */
 	msm_vidc_change_core_sub_state(core, CORE_SUBSTATE_MAX - 1, 0, __func__);
 


### PR DESCRIPTION
Extend the Iris driver to support PAS-based firmware loading and secure auth/reset on platforms where IOMMU is managed by Linux (non-Gunyah, non-QHEE).

Additionally, the Iris driver must map the firmware and its required resources to the firmware SID, which is now specified via the device tree el2 overlay.