### PR TITLE
video: driver: fix concurrent sessions issue on KLM targers

### DIFF
--- a/driver/platform/kodiak/src/kodiak.c
+++ b/driver/platform/kodiak/src/kodiak.c
@@ -283,8 +283,8 @@ static const struct msm_platform_core_capability core_data_kodiak_v0[] = {
 	{ENC_CODECS, H264 | HEVC | HEIC},
 	{DEC_CODECS, H264 | HEVC | VP9 | HEIC},
 	{MAX_SESSION_COUNT, 16},
-	{MAX_NUM_720P_SESSIONS, 8},
-	{MAX_NUM_1080P_SESSIONS, 4},
+	{MAX_NUM_720P_SESSIONS, 16},
+	{MAX_NUM_1080P_SESSIONS, 8},
 	{MAX_NUM_4K_SESSIONS, 2},
 	{MAX_SECURE_SESSION_COUNT, 3},
 	{MAX_RT_MBPF, 69362}, /* ((4096x2176)/256) x 2 */
@@ -317,13 +317,14 @@ static const struct msm_platform_core_capability core_data_kodiak_v0[] = {
 	{DEVICE_CAPS, V4L2_CAP_VIDEO_M2M_MPLANE | V4L2_CAP_META_CAPTURE | V4L2_CAP_STREAMING},
 	{PAGEFAULT_NON_FATAL, 1},
 	{PAGETABLE_CACHING, 0},
-	{DCVS, 1},
-	{DECODE_BATCH, 1},
+	{DCVS, 0},
+	{DECODE_BATCH, 0},
 	{DECODE_BATCH_TIMEOUT, 200},
 	{STATS_TIMEOUT_MS, 2000},
 	{AV_SYNC_WINDOW_SIZE, 40},
 	{NON_FATAL_FAULTS, 1},
 	{ENC_AUTO_FRAMERATE, 0},
+	{SKIP_DELAYED_UNMAP, 1},
 	};
 
 static struct msm_platform_inst_capability instance_cap_data_kodiak_v0[] = {
@@ -2384,11 +2385,12 @@ static const char * const kodiak_opp_pd_table[] = { "cx", NULL };
 
 /* name, clock id, scaling */
 static const struct clk_table kodiak_clk_table[] = {
-	{ "bus",			VIDEO_CC_MVSC_CTL_AXI_CLK,	0},
-	{ "vcodec_bus",			VIDEO_CC_MVS0_AXI_CLK,		0},
-	{ "core",			VIDEO_CC_MVS0_CORE_CLK,		0},
-	{ "vcodec_core",		VIDEO_CC_MVS0_CORE_CLK,		0},
-	{ "iface",			VIDEO_CC_VENUS_AHB_CLK,		0},
+	{ "bus",			VIDEO_CC_MVSC_CTL_AXI_CLK,		0},
+	{ "vcodec_bus",			VIDEO_CC_MVS0_AXI_CLK,			0},
+	{ "iface",			VIDEO_CC_VENUS_AHB_CLK,			0},
+	{ "core",			VIDEO_CC_MVSC_CORE_CLK,			0},
+	{ "vcodec_core",		VIDEO_CC_MVS0_CORE_CLK,			1,
+	  (u64[]) {460000048, 424000000, 335000000, 240000000, 133330000},      5},
 };
 
 const struct context_bank_table kodiak_context_bank_table[] = {

--- a/driver/platform/lemans/src/lemans.c
+++ b/driver/platform/lemans/src/lemans.c
@@ -248,14 +248,15 @@ static const struct msm_platform_core_capability core_data_lemans[] = {
 	{HW_RESPONSE_TIMEOUT, HW_RESPONSE_TIMEOUT_VALUE}, /* 1000 ms */
 	{SW_PC_DELAY,         SW_PC_DELAY_VALUE        }, /* 1500 ms (>HW_RESPONSE_TIMEOUT)*/
 	{FW_UNLOAD_DELAY,     FW_UNLOAD_DELAY_VALUE    }, /* 3000 ms (>SW_PC_DELAY)*/
-	{DCVS, 1},
-	{DECODE_BATCH, 1},
+	{DCVS, 0},
+	{DECODE_BATCH, 0},
 	{DECODE_BATCH_TIMEOUT, 200},
 	{STATS_TIMEOUT_MS, 2000},
 	{NON_FATAL_FAULTS, 1},
 	{ENC_AUTO_FRAMERATE, 1},
 	{DEVICE_CAPS, V4L2_CAP_VIDEO_M2M_MPLANE | V4L2_CAP_STREAMING},
 	{SUPPORTS_REQUESTS, 0},
+	{SKIP_DELAYED_UNMAP, 1},
 };
 
 static struct msm_platform_inst_capability instance_cap_data_lemans[] = {

--- a/driver/platform/monaco/src/monaco.c
+++ b/driver/platform/monaco/src/monaco.c
@@ -224,7 +224,7 @@ static const struct msm_platform_core_capability core_data_monaco[] = {
 	{DEC_CODECS, H264 | HEVC | VP9 | AV1},
 	{MAX_SESSION_COUNT, 16},
 	{MAX_NUM_720P_SESSIONS, 16},
-	{MAX_NUM_1080P_SESSIONS, 8},
+	{MAX_NUM_1080P_SESSIONS, 16},
 	{MAX_NUM_4K_SESSIONS, 4},
 	{MAX_NUM_8K_SESSIONS, 1},
 	{MAX_RT_MBPF, (((4096 * 2176) / 256) * 4)},	/* (4096*2176)/256 * 4 */
@@ -242,14 +242,15 @@ static const struct msm_platform_core_capability core_data_monaco[] = {
 	{HW_RESPONSE_TIMEOUT, HW_RESPONSE_TIMEOUT_VALUE}, /* 1000 ms */
 	{SW_PC_DELAY,         SW_PC_DELAY_VALUE        }, /* 1500 ms (>HW_RESPONSE_TIMEOUT)*/
 	{FW_UNLOAD_DELAY,     FW_UNLOAD_DELAY_VALUE    }, /* 3000 ms (>SW_PC_DELAY)*/
-	{DCVS, 1},
-	{DECODE_BATCH, 1},
+	{DCVS, 0},
+	{DECODE_BATCH, 0},
 	{DECODE_BATCH_TIMEOUT, 200},
 	{STATS_TIMEOUT_MS, 2000},
 	{NON_FATAL_FAULTS, 1},
 	{ENC_AUTO_FRAMERATE, 0},
 	{DEVICE_CAPS, V4L2_CAP_VIDEO_M2M_MPLANE | V4L2_CAP_STREAMING},
 	{SUPPORTS_REQUESTS, 0},
+	{SKIP_DELAYED_UNMAP, 1},
 };
 
 static struct msm_platform_inst_capability instance_cap_data_monaco[] = {

--- a/driver/vidc/src/msm_vidc_buffer.c
+++ b/driver/vidc/src/msm_vidc_buffer.c
@@ -220,6 +220,9 @@ u32 msm_vidc_decoder_input_size(struct msm_vidc_inst *inst)
 	struct v4l2_format *f;
 	u32 bitstream_size_overwrite = 0;
 	enum msm_vidc_codec_type codec;
+	struct msm_vidc_core *core;
+	struct msm_vidc_inst *i;
+	u32 count = 0;
 
 	bitstream_size_overwrite =
 		inst->capabilities[BITSTREAM_SIZE_OVERWRITE].value;
@@ -254,8 +257,12 @@ u32 msm_vidc_decoder_input_size(struct msm_vidc_inst *inst)
 	if (is_secure_session(inst))
 		div_factor = div_factor << 1;
 
+	core = inst->core;
+	list_for_each_entry(i, &core->instances, list)
+		count++;
+
 	/* For image session, use the actual resolution to calc buffer size */
-	if (is_image_session(inst)) {
+	if (is_image_session(inst) || count >= 16) {
 		base_res_mbs = num_mbs;
 		div_factor = 1;
 	}

--- a/driver/vidc/src/msm_vidc_driver.c
+++ b/driver/vidc/src/msm_vidc_driver.c
@@ -5246,9 +5246,6 @@ int msm_vidc_flush_read_only_buffers(struct msm_vidc_inst *inst,
 		if (ro_buf->attach && ro_buf->dmabuf)
 			call_mem_op(core, dma_buf_detach, core,
 				ro_buf->dmabuf, ro_buf->attach);
-		if (ro_buf->kvaddr && ro_buf->device_addr)
-			dma_free_attrs(&core->pdev->dev, ro_buf->buffer_size,
-					ro_buf->kvaddr, ro_buf->device_addr, ro_buf->dma_attrs);
 		if (ro_buf->dbuf_get)
 			call_mem_op(core, dma_buf_put, inst, ro_buf->dmabuf);
 		ro_buf->attach = NULL;
@@ -5327,9 +5324,10 @@ void msm_vidc_destroy_buffers(struct msm_vidc_inst *inst)
 				buf->attach, buf->sg_table);
 		if (buf->attach && buf->dmabuf)
 			call_mem_op(core, dma_buf_detach, core, buf->dmabuf, buf->attach);
-		if (buf->kvaddr && buf->device_addr)
-			dma_free_attrs(&core->pdev->dev, buf->buffer_size,
-					buf->kvaddr, buf->device_addr, buf->dma_attrs);
+		if (buf->kvaddr && buf->device_addr && refcount_read(&buf->refcount) > 0)
+			i_vpr_e(inst,
+				"%s: destroy ro buffer with Non-Zero refcount %d, daddr 0x%llx\n",
+					__func__, refcount_read(&buf->refcount), buf->device_addr);
 		if (buf->dbuf_get)
 			call_mem_op(core, dma_buf_put, inst, buf->dmabuf);
 		list_del_init(&buf->list);
@@ -5347,10 +5345,10 @@ void msm_vidc_destroy_buffers(struct msm_vidc_inst *inst)
 					buf->attach, buf->sg_table);
 			if (buf->attach && buf->dmabuf)
 				call_mem_op(core, dma_buf_detach, core, buf->dmabuf, buf->attach);
-			if (buf->kvaddr && buf->device_addr)
-				dma_free_attrs(&core->pdev->dev, buf->buffer_size,
-						buf->kvaddr, buf->device_addr, buf->dma_attrs);
-
+			if (buf->kvaddr && buf->device_addr && refcount_read(&buf->refcount) > 0)
+				i_vpr_e(inst,
+					"%s: destroying ext buffer, refcount %d, daddr 0x%llx\n",
+					__func__, refcount_read(&buf->refcount), buf->device_addr);
 			if (buf->dbuf_get) {
 				print_vidc_buffer(VIDC_ERR, "err ", "destroying: put dmabuf",
 						  inst, buf);

--- a/driver/vidc/src/msm_vidc_vb2.c
+++ b/driver/vidc/src/msm_vidc_vb2.c
@@ -267,22 +267,9 @@ void msm_vb2_put(void *buf_priv)
 	if (IS_ERR_OR_NULL(buf_priv))
 		return;
 
-	if (refcount_read(&buf->refcount) == 0)
-		return;
-
 	inst = buf->inst;
 	if (!inst || !inst->core)
 		return;
-
-	if (is_decode_session(inst) && is_output_buffer(buf->type)) {
-		list_for_each_entry_safe(temp, dummy, &inst->buffers.read_only.list, list) {
-			if (temp->device_addr != buf->device_addr)
-				continue;
-			buf->kvaddr = NULL;
-			buf->device_addr = 0x0;
-			return;
-		}
-	}
 
 	core = inst->core;
 


### PR DESCRIPTION
When the session count exceeds 16, use the actual resolution
buffer size instead of the fixed 4K buffer to optimize memory
usage and avoid memory exhaustion in 24/32 concurrent session
scenarios.

Updated session counts and related parameters in KLM platform data

Added clock scaling support for the Kodiak target
