### PR TITLE
video: driver: correct UBWC configuration on Kodiak platform

### DIFF
--- a/driver/platform/kodiak/src/kodiak.c
+++ b/driver/platform/kodiak/src/kodiak.c
@@ -2350,9 +2350,9 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_kodi
 		NULL},
 };
 
-/* Default UBWC config for LPDDR5 */
+/* Default UBWC config for LPDDR4 */
 static struct msm_vidc_ubwc_config_data ubwc_config_kodiak[] = {
-	UBWC_CONFIG(8, 32, 15, 0, 1, 1, 1),
+	UBWC_CONFIG(8, 32, 14, 0, 1, 1, 1),
 };
 
 static struct msm_vidc_format_capability format_data_kodiak = {


### PR DESCRIPTION
Incorrect UBWC configuration values caused video corruption. 
Update the UBWC settings on the Kodiak platform to resolve the issue.