### PR TITLE
video: driver: use global UBWC config on KLM platforms

### DIFF
--- a/driver/platform/common/inc/msm_vidc_platform.h
+++ b/driver/platform/common/inc/msm_vidc_platform.h
@@ -8,6 +8,92 @@
 #define _MSM_VIDC_PLATFORM_H_
 
 #include <linux/pm_domain.h>
+#include <linux/version.h>
+
+#ifndef MSM_VIDC_HAS_QCOM_UBWC_HEADER
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
+#define MSM_VIDC_HAS_QCOM_UBWC_HEADER 1
+#else
+#define MSM_VIDC_HAS_QCOM_UBWC_HEADER 0
+#endif
+#endif
+
+/*
+ * Helper functions (qcom_ubwc_min_acc_length_64b, qcom_ubwc_macrotile_mode,
+ * qcom_ubwc_bank_spread, qcom_ubwc_swizzle) were added to the kernel header
+ * in v7.1.  Provide compat implementations for older kernels.
+ */
+#ifndef MSM_VIDC_HAS_QCOM_UBWC_HELPERS
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+#define MSM_VIDC_HAS_QCOM_UBWC_HELPERS 1
+#else
+#define MSM_VIDC_HAS_QCOM_UBWC_HELPERS 0
+#endif
+#endif
+
+#if MSM_VIDC_HAS_QCOM_UBWC_HEADER
+#include <linux/soc/qcom/ubwc.h>
+#else
+/*
+ * Compat definitions for kernels that do not yet provide
+ * <linux/soc/qcom/ubwc.h>.  Once support for those kernels is dropped,
+ * this entire #else block can be removed.
+ */
+enum ubwc_version {
+	UBWC_1_0 = 0x10,
+	UBWC_2_0 = 0x20,
+	UBWC_3_0 = 0x30,
+	UBWC_4_0 = 0x40,
+};
+
+#define UBWC_SWIZZLE_ENABLE_LVL1	BIT(0)
+#define UBWC_SWIZZLE_ENABLE_LVL2	BIT(1)
+#define UBWC_SWIZZLE_ENABLE_LVL3	BIT(2)
+
+struct qcom_ubwc_cfg_data {
+	u32	ubwc_enc_version;
+	u32	ubwc_dec_version;
+	u32	ubwc_swizzle;
+	int	highest_bank_bit;
+	bool	ubwc_bank_spread;
+	bool	macrotile_mode;
+};
+
+static inline const struct qcom_ubwc_cfg_data *qcom_ubwc_config_get_data(void)
+{
+	return ERR_PTR(-ENODEV);
+}
+#endif /* MSM_VIDC_HAS_QCOM_UBWC_HEADER */
+
+#if !MSM_VIDC_HAS_QCOM_UBWC_HELPERS
+/*
+ * Compat helper functions for kernels < v7.1 that have
+ * <linux/soc/qcom/ubwc.h> but not the inline helpers.
+ * Once v7.1 is the minimum supported kernel these can be removed.
+ */
+static inline bool qcom_ubwc_min_acc_length_64b(const struct qcom_ubwc_cfg_data *cfg)
+{
+	return cfg->ubwc_enc_version == UBWC_1_0 &&
+		(cfg->ubwc_dec_version == UBWC_2_0 ||
+		 cfg->ubwc_dec_version == UBWC_3_0);
+}
+
+static inline bool qcom_ubwc_macrotile_mode(const struct qcom_ubwc_cfg_data *cfg)
+{
+	return cfg->macrotile_mode;
+}
+
+static inline bool qcom_ubwc_bank_spread(const struct qcom_ubwc_cfg_data *cfg)
+{
+	return cfg->ubwc_bank_spread;
+}
+
+static inline u32 qcom_ubwc_swizzle(const struct qcom_ubwc_cfg_data *cfg)
+{
+	return cfg->ubwc_swizzle;
+}
+#endif /* !MSM_VIDC_HAS_QCOM_UBWC_HELPERS */
+
 #include "msm_vidc_internal.h"
 #include "msm_vidc_core.h"
 
@@ -15,17 +101,6 @@
 #define DDR_TYPE_LPDDR4X  0x7
 #define DDR_TYPE_LPDDR5   0x8
 #define DDR_TYPE_LPDDR5X  0x9
-
-#define UBWC_CONFIG(mc, ml, hbb, bs1, bs2, bs3, bsp) \
-{	                                                 \
-	.max_channels = mc,                              \
-	.mal_length = ml,                                \
-	.highest_bank_bit = hbb,                         \
-	.bank_swzl_level = bs1,                          \
-	.bank_swz2_level = bs2,                          \
-	.bank_swz3_level = bs3,                          \
-	.bank_spreading = bsp,                           \
-}
 
 #define EFUSE_ENTRY(sa, s, m, sh, p) \
 {	                                 \
@@ -113,16 +188,6 @@ struct device_region_table {
 	u32              size;
 	u32              dev_addr;
 	u32              region;
-};
-
-struct msm_vidc_ubwc_config_data {
-	u32              max_channels;
-	u32              mal_length;
-	u32              highest_bank_bit;
-	u32              bank_swzl_level;
-	u32              bank_swz2_level;
-	u32              bank_swz3_level;
-	u32              bank_spreading;
 };
 
 struct codec_info {
@@ -245,7 +310,7 @@ struct msm_vidc_platform_data {
 	unsigned int reg_prst_tbl_size;
 	const struct device_region_table *dev_reg_tbl;
 	unsigned int dev_reg_tbl_size;
-	struct msm_vidc_ubwc_config_data *ubwc_config;
+	const struct qcom_ubwc_cfg_data *ubwc_config;
 	u32 clock_source_scaling_ratio;
 	const char *fwname;
 	u32 pas_id;
@@ -344,6 +409,7 @@ static inline bool is_mmrm_supported(struct msm_vidc_core *core)
 }
 
 int msm_vidc_init_platform_capabilities(struct msm_vidc_core *core);
+int msm_vidc_update_ubwc_config(struct msm_vidc_core *core);
 enum msm_vidc_hw_version msm_vidc_get_hw_version(void);
 int msm_vidc_read_efuse(struct msm_vidc_core *core);
 

--- a/driver/platform/common/src/msm_vidc_platform.c
+++ b/driver/platform/common/src/msm_vidc_platform.c
@@ -433,6 +433,10 @@ int msm_vidc_init_platform_capabilities(struct msm_vidc_core *core)
 	if (rc)
 		return rc;
 
+	rc = msm_vidc_update_ubwc_config(core);
+	if (rc)
+		return rc;
+
 	rc = msm_vidc_init_vpu(core);
 
 	return rc;

--- a/driver/platform/common/src/msm_vidc_ubwc.c
+++ b/driver/platform/common/src/msm_vidc_ubwc.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <linux/err.h>
+
+#include "msm_vidc_platform.h"
+#include "msm_vidc_debug.h"
+
+#if MSM_VIDC_HAS_QCOM_UBWC_HEADER
+int msm_vidc_update_ubwc_config(struct msm_vidc_core *core)
+{
+	const struct qcom_ubwc_cfg_data *ubwc_cfg;
+
+	ubwc_cfg = qcom_ubwc_config_get_data();
+	if (IS_ERR(ubwc_cfg)) {
+		long rc = PTR_ERR(ubwc_cfg);
+
+		if (rc == -EINVAL) {
+			/*
+			 * Platform UBWC data is not yet present in the kernel
+			 * database.  Fall back to the per-platform defaults
+			 * already set in platform data.
+			 */
+			d_vpr_h("%s: no global UBWC config, using platform defaults\n",
+				__func__);
+			return 0;
+		}
+
+		d_vpr_e("%s: failed to get global UBWC config: %ld\n",
+			__func__, rc);
+		return rc;
+	}
+
+	core->platform->data.ubwc_config = ubwc_cfg;
+
+	d_vpr_h("%s: global UBWC config applied\n", __func__);
+
+	return 0;
+}
+#else
+int msm_vidc_update_ubwc_config(struct msm_vidc_core *core)
+{
+	return 0;
+}
+#endif

--- a/driver/platform/hamoa/src/hamoa.c
+++ b/driver/platform/hamoa/src/hamoa.c
@@ -1855,11 +1855,6 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_hamo
 		NULL},
 };
 
-/* Default UBWC config for LPDDR5 */
-static struct msm_vidc_ubwc_config_data ubwc_config_hamoa[] = {
-	UBWC_CONFIG(8, 32, 17, 0, 1, 1, 1),
-};
-
 static struct msm_vidc_format_capability format_data_hamoa = {
 	.codec_info = codec_data_hamoa,
 	.codec_info_size = ARRAY_SIZE(codec_data_hamoa),
@@ -2094,7 +2089,6 @@ static const struct msm_vidc_platform_data hamoa_data = {
 	.csc_data.vpe_csc_custom_bias_coeff = vpe_csc_custom_bias_coeff,
 	.csc_data.vpe_csc_custom_matrix_coeff = vpe_csc_custom_matrix_coeff,
 	.csc_data.vpe_csc_custom_limit_coeff = vpe_csc_custom_limit_coeff,
-	.ubwc_config = ubwc_config_hamoa,
 	.format_data = &format_data_hamoa,
 
 	/* decoder properties related*/

--- a/driver/platform/kodiak/src/kodiak.c
+++ b/driver/platform/kodiak/src/kodiak.c
@@ -2351,8 +2351,13 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_kodi
 };
 
 /* Default UBWC config for LPDDR4 */
-static struct msm_vidc_ubwc_config_data ubwc_config_kodiak[] = {
-	UBWC_CONFIG(8, 32, 14, 0, 1, 1, 1),
+static const struct qcom_ubwc_cfg_data ubwc_config_kodiak = {
+	.ubwc_enc_version = UBWC_3_0,
+	.ubwc_dec_version = UBWC_4_0,
+	.ubwc_swizzle     = UBWC_SWIZZLE_ENABLE_LVL2 | UBWC_SWIZZLE_ENABLE_LVL3,
+	.highest_bank_bit = 14,
+	.ubwc_bank_spread = true,
+	.macrotile_mode   = true,
 };
 
 static struct msm_vidc_format_capability format_data_kodiak = {
@@ -2521,7 +2526,7 @@ static const struct msm_vidc_platform_data kodiak_data_v0 = {
 	.csc_data.vpe_csc_custom_bias_coeff = vpe_csc_custom_bias_coeff,
 	.csc_data.vpe_csc_custom_matrix_coeff = vpe_csc_custom_matrix_coeff,
 	.csc_data.vpe_csc_custom_limit_coeff = vpe_csc_custom_limit_coeff,
-	.ubwc_config = ubwc_config_kodiak,
+	.ubwc_config = &ubwc_config_kodiak,
 	.format_data = &format_data_kodiak,
 
 	/* decoder properties related*/

--- a/driver/platform/lemans/src/lemans.c
+++ b/driver/platform/lemans/src/lemans.c
@@ -1822,11 +1822,6 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_lema
 		NULL},
 };
 
-/* Default UBWC config for LPDDR5 */
-static struct msm_vidc_ubwc_config_data ubwc_config_lemans[] = {
-	UBWC_CONFIG(8, 32, 13, 0, 0, 1, 1),
-};
-
 static struct msm_vidc_format_capability format_data_lemans = {
 	.codec_info = codec_data_lemans,
 	.codec_info_size = ARRAY_SIZE(codec_data_lemans),
@@ -2059,7 +2054,6 @@ static const struct msm_vidc_platform_data lemans_data = {
 	.csc_data.vpe_csc_custom_bias_coeff = vpe_csc_custom_bias_coeff,
 	.csc_data.vpe_csc_custom_matrix_coeff = vpe_csc_custom_matrix_coeff,
 	.csc_data.vpe_csc_custom_limit_coeff = vpe_csc_custom_limit_coeff,
-	.ubwc_config = ubwc_config_lemans,
 	.format_data = &format_data_lemans,
 
 	/* decoder properties related*/

--- a/driver/platform/monaco/src/monaco.c
+++ b/driver/platform/monaco/src/monaco.c
@@ -1811,8 +1811,13 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_mona
 };
 
 /* Default UBWC config for LPDDR5 */
-static struct msm_vidc_ubwc_config_data ubwc_config_monaco[] = {
-	UBWC_CONFIG(8, 32, 13, 0, 0, 1, 1),
+static const struct qcom_ubwc_cfg_data ubwc_config_monaco = {
+	.ubwc_enc_version = UBWC_4_0,
+	.ubwc_dec_version = UBWC_4_0,
+	.ubwc_swizzle     = UBWC_SWIZZLE_ENABLE_LVL2 | UBWC_SWIZZLE_ENABLE_LVL3,
+	.highest_bank_bit = 16,
+	.ubwc_bank_spread = true,
+	.macrotile_mode   = true,
 };
 
 static struct msm_vidc_format_capability format_data_monaco = {
@@ -2005,7 +2010,7 @@ static const struct msm_vidc_platform_data monaco_data = {
 	.csc_data.vpe_csc_custom_bias_coeff = vpe_csc_custom_bias_coeff,
 	.csc_data.vpe_csc_custom_matrix_coeff = vpe_csc_custom_matrix_coeff,
 	.csc_data.vpe_csc_custom_limit_coeff = vpe_csc_custom_limit_coeff,
-	.ubwc_config = ubwc_config_monaco,
+	.ubwc_config = &ubwc_config_monaco,
 	.format_data = &format_data_monaco,
 
 	/* decoder properties related*/

--- a/driver/vidc/src/hfi_packet.c
+++ b/driver/vidc/src/hfi_packet.c
@@ -399,6 +399,7 @@ int hfi_packet_sys_init(struct msm_vidc_core *core,
 {
 	int rc = 0;
 	u32 payload = 0;
+	u32 swizzle = 0;
 	u32 synx_client_data[2];
 
 	rc = hfi_create_header(pkt, pkt_size,
@@ -425,7 +426,7 @@ int hfi_packet_sys_init(struct msm_vidc_core *core,
 		goto err_sys_init;
 
 	/* HFI_PROP_UBWC_MAX_CHANNELS */
-	payload = core->platform->data.ubwc_config->max_channels;
+	payload = qcom_ubwc_macrotile_mode(core->platform->data.ubwc_config) ? 8 : 4;
 	d_vpr_h("%s: ubwc max channels %d\n", __func__, payload);
 	rc = hfi_create_packet(pkt, pkt_size,
 			       HFI_PROP_UBWC_MAX_CHANNELS,
@@ -439,7 +440,7 @@ int hfi_packet_sys_init(struct msm_vidc_core *core,
 		goto err_sys_init;
 
 	/* HFI_PROP_UBWC_MAL_LENGTH */
-	payload = core->platform->data.ubwc_config->mal_length;
+	payload = qcom_ubwc_min_acc_length_64b(core->platform->data.ubwc_config) ? 64 : 32;
 	d_vpr_h("%s: ubwc mal length %d\n", __func__, payload);
 	rc = hfi_create_packet(pkt, pkt_size,
 			       HFI_PROP_UBWC_MAL_LENGTH,
@@ -454,7 +455,7 @@ int hfi_packet_sys_init(struct msm_vidc_core *core,
 
 	/* HFI_PROP_UBWC_HBB */
 	payload = core->platform->data.ubwc_config->highest_bank_bit;
-	d_vpr_h("%s: ubwc hbb %d\n", __func__, payload);
+	d_vpr_h("%s: ubwc hbb %u\n", __func__, payload);
 	rc = hfi_create_packet(pkt, pkt_size,
 			       HFI_PROP_UBWC_HBB,
 			       HFI_HOST_FLAGS_NONE,
@@ -466,8 +467,10 @@ int hfi_packet_sys_init(struct msm_vidc_core *core,
 	if (rc)
 		goto err_sys_init;
 
+	swizzle = qcom_ubwc_swizzle(core->platform->data.ubwc_config);
+
 	/* HFI_PROP_UBWC_BANK_SWZL_LEVEL1 */
-	payload = core->platform->data.ubwc_config->bank_swzl_level;
+	payload = !!(swizzle & UBWC_SWIZZLE_ENABLE_LVL1);
 	d_vpr_h("%s: ubwc swzl1 %d\n", __func__, payload);
 	rc = hfi_create_packet(pkt, pkt_size,
 				   HFI_PROP_UBWC_BANK_SWZL_LEVEL1,
@@ -481,7 +484,7 @@ int hfi_packet_sys_init(struct msm_vidc_core *core,
 		goto err_sys_init;
 
 	/* HFI_PROP_UBWC_BANK_SWZL_LEVEL2 */
-	payload = core->platform->data.ubwc_config->bank_swz2_level;
+	payload = !!(swizzle & UBWC_SWIZZLE_ENABLE_LVL2);
 	d_vpr_h("%s: ubwc swzl2 %d\n", __func__, payload);
 	rc = hfi_create_packet(pkt, pkt_size,
 			       HFI_PROP_UBWC_BANK_SWZL_LEVEL2,
@@ -495,7 +498,7 @@ int hfi_packet_sys_init(struct msm_vidc_core *core,
 		goto err_sys_init;
 
 	/* HFI_PROP_UBWC_BANK_SWZL_LEVEL3 */
-	payload = core->platform->data.ubwc_config->bank_swz3_level;
+	payload = !!(swizzle & UBWC_SWIZZLE_ENABLE_LVL3);
 	d_vpr_h("%s: ubwc swzl3 %d\n", __func__, payload);
 	rc = hfi_create_packet(pkt, pkt_size,
 			       HFI_PROP_UBWC_BANK_SWZL_LEVEL3,
@@ -509,7 +512,7 @@ int hfi_packet_sys_init(struct msm_vidc_core *core,
 		goto err_sys_init;
 
 	/* HFI_PROP_UBWC_BANK_SPREADING */
-	payload = core->platform->data.ubwc_config->bank_spreading;
+	payload = qcom_ubwc_bank_spread(core->platform->data.ubwc_config);
 	d_vpr_h("%s: ubwc bank spreading %d\n", __func__, payload);
 	rc = hfi_create_packet(pkt, pkt_size,
 			       HFI_PROP_UBWC_BANK_SPREADING,

--- a/msm_video/Kbuild
+++ b/msm_video/Kbuild
@@ -194,6 +194,7 @@ msm_video-objs += $(VIDEO_DRIVER_REL_PATH)/platform/nordau/src/msm_vidc_nordau.o
 endif
 
 msm_video-objs += $(VIDEO_DRIVER_REL_PATH)/platform/common/src/msm_vidc_platform.o \
+                  $(VIDEO_DRIVER_REL_PATH)/platform/common/src/msm_vidc_ubwc.o \
                   $(VIDEO_DRIVER_REL_PATH)/platform/common/src/msm_vidc_platform_ext.o \
                   $(VIDEO_DRIVER_REL_PATH)/variant/common/src/msm_vidc_variant.o \
                   $(VIDEO_DRIVER_REL_PATH)/vidc/src/msm_vidc_v4l2.o \

--- a/video/Kbuild
+++ b/video/Kbuild
@@ -206,6 +206,7 @@ iris_vpu-objs +=  $(VIDEO_DRIVER_REL_PATH)/platform/lemans/src/lemans.o \
 endif
 
 iris_vpu-objs +=  $(VIDEO_DRIVER_REL_PATH)/platform/common/src/msm_vidc_platform.o \
+                  $(VIDEO_DRIVER_REL_PATH)/platform/common/src/msm_vidc_ubwc.o \
                   $(VIDEO_DRIVER_REL_PATH)/variant/common/src/msm_vidc_variant.o \
                   $(VIDEO_DRIVER_REL_PATH)/vidc/src/msm_vidc_v4l2.o \
                   $(VIDEO_DRIVER_REL_PATH)/vidc/src/msm_vidc_vb2.o \


### PR DESCRIPTION
- Use kernel global UBWC config database for kodiak/lemans/monaco
- Fall back to existing per-platform UBWC defaults when global data is unavailable.