### PR TITLE
video: driver: Fix encoder frame interval enumeration

### DIFF
--- a/driver/vidc/src/msm_vidc.c
+++ b/driver/vidc/src/msm_vidc.c
@@ -718,10 +718,10 @@ int msm_vidc_enum_frameintervals(struct msm_vidc_inst *inst, void *data)
 
 	fival->type = V4L2_FRMIVAL_TYPE_STEPWISE;
 	fival->stepwise.min.numerator = 1;
-	fival->stepwise.min.denominator =
-			min_t(u32, fps, inst->capabilities[FRAME_RATE].max >> 16);
+	fival->stepwise.min.denominator = 1;
 	fival->stepwise.max.numerator = 1;
-	fival->stepwise.max.denominator = 1;
+	fival->stepwise.max.denominator =
+			min_t(u32, fps, inst->capabilities[FRAME_RATE].max >> 16);
 	fival->stepwise.step.numerator = 1;
 	fival->stepwise.step.denominator = (inst->capabilities[FRAME_RATE].max >> 16);
 


### PR DESCRIPTION
Advertise the encoder stepwise frame interval range correctly from 1 fps to the maximum supported fps for the requested resolution.

This fixes incorrect frame rate capability reporting and avoids GStreamer caps negotiation failures for encode pipelines using rational frame rates such as 30000/1001.

Change-Id: If607969c6ec37de3f71940014312f7f18a3380b4