### PR TITLE
video: driver: Add 24 session support for monaco

### DIFF
--- a/driver/platform/monaco/src/monaco.c
+++ b/driver/platform/monaco/src/monaco.c
@@ -222,8 +222,8 @@ static const struct msm_platform_core_capability core_data_monaco[] = {
 	/* {type, value} */
 	{ENC_CODECS, H264 | HEVC},
 	{DEC_CODECS, H264 | HEVC | VP9 | AV1},
-	{MAX_SESSION_COUNT, 16},
-	{MAX_NUM_720P_SESSIONS, 16},
+	{MAX_SESSION_COUNT, 24},
+	{MAX_NUM_720P_SESSIONS, 24},
 	{MAX_NUM_1080P_SESSIONS, 16},
 	{MAX_NUM_4K_SESSIONS, 4},
 	{MAX_NUM_8K_SESSIONS, 1},


### PR DESCRIPTION
Increase the max session count for Monaco from 16 to 24.