### PR TITLE
video: driver: Add session ops function ptr support for adjusting slice max mb

### DIFF
--- a/driver/variant/iris2/inc/msm_vidc_buffer_iris2.h
+++ b/driver/variant/iris2/inc/msm_vidc_buffer_iris2.h
@@ -16,4 +16,5 @@ int msm_buffer_min_count_iris2(struct msm_vidc_inst *inst,
 		enum msm_vidc_buffer_type buffer_type);
 int msm_buffer_extra_count_iris2(struct msm_vidc_inst *inst,
 		enum msm_vidc_buffer_type buffer_type);
+int msm_vidc_encoder_decide_slice_max_mb_iris2(struct msm_vidc_inst *inst);
 #endif // __H_MSM_VIDC_BUFFER_IRIS2_H__

--- a/driver/variant/iris2/src/msm_vidc_buffer_iris2.c
+++ b/driver/variant/iris2/src/msm_vidc_buffer_iris2.c
@@ -719,3 +719,31 @@ int msm_buffer_extra_count_iris2(struct msm_vidc_inst *inst,
 	i_vpr_l(inst, "extra_count: type: %11s, count: %9u\n", buf_name(buffer_type), count);
 	return count;
 }
+
+int msm_vidc_encoder_decide_slice_max_mb_iris2(struct msm_vidc_inst *inst)
+{
+	struct v4l2_format *f = &inst->fmts[INPUT_PORT];
+	u32 slice_val, output_height, output_width, mbpf = 0;
+
+	if (is_decode_session(inst) || inst->capabilities[SLICE_MODE].value !=
+			V4L2_MPEG_VIDEO_MULTI_SLICE_MODE_MAX_MB)
+		return 0;
+
+	/**
+	 * In case of slice mode SLICE_MAX_MB, adjust SLICE_MAX_MB cap
+	 * w.r.to minimum and maximum possible slice MB's based on
+	 * the resolution and codec.
+	 */
+	output_width = f->fmt.pix_mp.width;
+	output_height = f->fmt.pix_mp.height;
+	slice_val = inst->capabilities[SLICE_MAX_MB].value;
+
+	if (inst->codec == MSM_VIDC_HEVC)
+		mbpf = NUM_MBS_PER_FRAME_HEVC(output_height, output_width);
+	else
+		mbpf = NUM_MBS_PER_FRAME(output_height, output_width);
+
+	slice_val = max(slice_val, mbpf / MAX_SLICES_PER_FRAME);
+
+	return slice_val;
+}

--- a/driver/variant/iris2/src/msm_vidc_iris2.c
+++ b/driver/variant/iris2/src/msm_vidc_iris2.c
@@ -1128,6 +1128,7 @@ static struct msm_vidc_session_ops msm_session_ops = {
 	.decide_work_route = msm_vidc_decide_work_route_iris2,
 	.decide_work_mode = msm_vidc_decide_work_mode_iris2,
 	.decide_quality_mode = msm_vidc_decide_quality_mode_iris2,
+	.decide_slice_max_mb = msm_vidc_encoder_decide_slice_max_mb_iris2,
 };
 
 int msm_vidc_init_iris2(struct msm_vidc_core *core)


### PR DESCRIPTION
- For a specific resolution and codec, min and max possible SLICE_MAX_MB values can be calculated using variant specific HFI macros.