### PR TITLE
video: Kbuild: detect UBWC helper functions at build time

### DIFF
--- a/video/Kbuild
+++ b/video/Kbuild
@@ -3,6 +3,12 @@
 VIDEO_DRIVER_ABS_PATH := $(VIDEO_ROOT)/video/driver
 VIDEO_DRIVER_REL_PATH := ../video/driver
 
+UBWC_H := $(KERNEL_SRC)/include/linux/soc/qcom/ubwc.h
+HAS_UBWC_HELPERS := $(shell grep -qs 'qcom_ubwc_min_acc_length_64b' $(UBWC_H) && echo yes || echo no)
+ifeq ($(HAS_UBWC_HELPERS),yes)
+  ccflags-y += -DMSM_VIDC_HAS_QCOM_UBWC_HELPERS=1
+endif
+
 MDT_LOADER_H := $(KERNEL_SRC)/include/linux/soc/qcom/mdt_loader.h
 
 HAS_MDT_PAS_LOAD := $(shell grep -qs 'qcom_mdt_pas_load' $(MDT_LOADER_H) && echo yes || echo no)


### PR DESCRIPTION
The UBWC helper functions were added to <linux/soc/qcom/ubwc.h> in the linux-qcom 6.18 kernel via backported upstream commits, but are not yet present in the linux-yocto 6.18 kernel.

A version-number check cannot distinguish between the two kernels. When the helpers are found, pass -DMSM_VIDC_HAS_QCOM_UBWC_HELPERS=1 so that the #ifndef guard in msm_vidc_platform.h skips the compat definitions, avoiding redefinition errors against linux-qcom 6.18 while keeping the compat path intact for other kernels.