### PR TITLE
ci: trigger packaging repo promote on tag release

### DIFF
--- a/.github/workflows/trigger-pkg-promote.yml
+++ b/.github/workflows/trigger-pkg-promote.yml
@@ -1,0 +1,63 @@
+name: Trigger Package Promote on Tag Release
+
+on:
+  push:
+    tags:
+      - 'v*'    # Matches tags like v1.0.10, v1.1.0, etc.
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-promote:
+    name: Trigger Promote New Upstream Version in packaging repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0    # Fetch all history and branches to check tag ancestry
+
+      - name: Check if tag is on video.qclinux.main branch
+        id: check-branch
+        run: |
+          TAG_COMMIT=$(git rev-list -n 1 "${{ github.ref_name }}")
+          echo "Tag commit: $TAG_COMMIT"
+
+          # Check if the tag commit is reachable from video.qclinux.main
+          if git merge-base --is-ancestor "$TAG_COMMIT" origin/video.qclinux.main; then
+            echo "Tag is on video.qclinux.main branch, proceeding with promote."
+            echo "should_promote=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag is NOT on video.qclinux.main branch, skipping promote."
+            echo "should_promote=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger Promote New Upstream Version (Suites)
+        if: steps.check-branch.outputs.should_promote == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            console.log(`New upstream tag detected: ${tag}`);
+
+            const pkgRepo = '${{ vars.PKG_REPO_GITHUB_NAME }}';
+            const [owner, repo] = pkgRepo.split('/');
+
+            // Trigger promote-upstream-suites.yml which promotes all three
+            // packaging suites (qcom/debian/latest, qcom/debian/trixie,
+            // qcom/ubuntu/resolute) in a single workflow run.
+            // The ref must point to the branch that contains the workflow file.
+            // promote-upstream-suites.yml lives on the 'main' branch of
+            // pkg-video-driver (the default/control branch).
+            await github.rest.actions.createWorkflowDispatch({
+              owner: owner,
+              repo: repo,
+              workflow_id: 'promote-upstream-suites.yml',
+              ref: 'main',
+              inputs: {
+                'upstream-tag': tag
+              }
+            });
+            console.log(`Successfully triggered Promote New Upstream Version (Suites) for tag: ${tag} in ${pkgRepo}`);


### PR DESCRIPTION
When a new upstream tag (v*) is pushed to this repository, automatically trigger the Promote New Upstream Version (Suites) workflow in the packaging repository, but only if the tag is associated with the video.qclinux.main branch.

CRs-Fixed: 4559917