### PR TITLE
video: driver: introduce GPL SPDX headers to build and config files

### DIFF
--- a/.github/workflows/trigger-pkg-promote.yml
+++ b/.github/workflows/trigger-pkg-promote.yml
@@ -1,0 +1,42 @@
+name: Trigger Package Promote on Tag Release
+
+on:
+  push:
+    tags:
+      - 'v*'    # Matches tags like v1.0.10, v1.1.0, etc.
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-promote:
+    name: Trigger Promote New Upstream Version in packaging repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Promote New Upstream Version (Suites)
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            console.log(`New upstream tag detected: ${tag}`);
+
+            const pkgRepo = '${{ vars.PKG_REPO_GITHUB_NAME }}';
+            const [owner, repo] = pkgRepo.split('/');
+
+            // Trigger promote-upstream-suites.yml which promotes all three
+            // packaging suites (qcom/debian/latest, qcom/debian/trixie,
+            // qcom/ubuntu/resolute) in a single workflow run.
+            // The ref must point to the branch that contains the workflow file.
+            // promote-upstream-suites.yml lives on the 'main' branch of
+            // pkg-video-driver (the default/control branch).
+            await github.rest.actions.createWorkflowDispatch({
+              owner: owner,
+              repo: repo,
+              workflow_id: 'promote-upstream-suites.yml',
+              ref: 'main',
+              inputs: {
+                'upstream-tag': tag
+              }
+            });
+            console.log(`Successfully triggered Promote New Upstream Version (Suites) for tag: ${tag} in ${pkgRepo}`);

--- a/Kbuild
+++ b/Kbuild
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
 ifeq ($(CONFIG_MSM_VIDC_ANDROID), m)
 obj-m := msm_video/
 else

--- a/config/chora_video.h
+++ b/config/chora_video.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-onl
+/* SPDX-License-Identifier: GPL-2.0-only */
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  */

--- a/video_kernel_headers.py
+++ b/video_kernel_headers.py
@@ -1,8 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # Copyright (c) 2020-2021, The Linux Foundation. All rights reserved.
-#
-# This program is free software; you can redistribute it and/or modify it
-# under the terms of the GNU General Public License version 2 as published by
-# the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
Introduce SPDX-License-Identifier: GPL-2.0-only headers across build and configuration files to standardize license annotation and improve license visibility.

Change-Id: I2f3d1a3d56eccc4d8ffc1fa6670cd6186d2c67f1

✖ source-license-headers-exist:
✖ video_kernel_headers.py: The first 200 lines do not contain the pattern(s): SPDX-License-Identifier|Redistribution and use in source and binary forms, with or without