### PR TITLE
video: driver: copy struct v4l2_format by assignment

### DIFF
--- a/driver/vidc/src/msm_vdec.c
+++ b/driver/vidc/src/msm_vdec.c
@@ -2550,7 +2550,7 @@ int msm_vdec_s_fmt(struct msm_vidc_inst *inst, struct v4l2_format *f)
 		i_vpr_e(inst, "%s: invalid type %d\n", __func__, f->type);
 		goto err_invalid_fmt;
 	}
-	memcpy(f, fmt, sizeof(struct v4l2_format));
+	*f = *fmt;
 
 err_invalid_fmt:
 	return rc;
@@ -2565,7 +2565,7 @@ int msm_vdec_g_fmt(struct msm_vidc_inst *inst, struct v4l2_format *f)
 	if (port < 0)
 		return -EINVAL;
 
-	memcpy(f, &inst->fmts[port], sizeof(struct v4l2_format));
+	*f = inst->fmts[port];
 
 	return rc;
 }

--- a/driver/vidc/src/msm_venc.c
+++ b/driver/vidc/src/msm_venc.c
@@ -1193,7 +1193,7 @@ int msm_venc_s_fmt_output(struct msm_vidc_inst *inst, struct v4l2_format *f)
 		inst->buffers.output.extra_count);
 
 	/* finally update client format */
-	memcpy(f, fmt, sizeof(struct v4l2_format));
+	*f = *fmt;
 	return rc;
 }
 
@@ -1219,7 +1219,7 @@ static int msm_venc_s_fmt_output_meta(struct msm_vidc_inst *inst, struct v4l2_fo
 			inst->buffers.output.actual_count;
 	inst->buffers.output_meta.size = fmt->fmt.meta.buffersize;
 
-	memcpy(f, fmt, sizeof(struct v4l2_format));
+	*f = *fmt;
 
 	i_vpr_h(inst, "%s: type: OUTPUT_META, size %u min_count %d extra_count %d\n",
 		__func__, fmt->fmt.meta.buffersize,
@@ -1324,7 +1324,7 @@ static int msm_venc_s_fmt_input(struct msm_vidc_inst *inst, struct v4l2_format *
 		inst->buffers.input.extra_count);
 
 	/* finally update client format */
-	memcpy(f, fmt, sizeof(struct v4l2_format));
+	*f = *fmt;
 
 	return rc;
 }
@@ -1351,7 +1351,7 @@ static int msm_venc_s_fmt_input_meta(struct msm_vidc_inst *inst, struct v4l2_for
 			inst->buffers.input.actual_count;
 	inst->buffers.input_meta.size = fmt->fmt.meta.buffersize;
 
-	memcpy(f, fmt, sizeof(struct v4l2_format));
+	*f = *fmt;
 
 	i_vpr_h(inst, "%s: type: INPUT_META, size %u min_count %d extra_count %d\n",
 		__func__, fmt->fmt.meta.buffersize,
@@ -1403,7 +1403,7 @@ int msm_venc_g_fmt(struct msm_vidc_inst *inst, struct v4l2_format *f)
 	if (port < 0)
 		return -EINVAL;
 
-	memcpy(f, &inst->fmts[port], sizeof(struct v4l2_format));
+	*f = inst->fmts[port];
 
 	return rc;
 }


### PR DESCRIPTION
GCC 16.1 with -Wstringop-overread (turned into an error by the driver's own -Werror) rejects the byte-wise copies of a whole struct v4l2_format:

  msm_venc.c:1327:9: error: 'memcpy' reading 208 bytes from a region
  of size 0 [-Werror=stringop-overread]
  note: source object is likely at address zero

After msm_venc_s_fmt_input() is inlined into msm_venc_s_fmt(), the compiler's value-range analysis mis-judges the source object (&inst->fmts[INPUT_PORT]) as a zero-sized region at address zero and rejects the memcpy(). The source is a regular member of struct msm_vidc_inst and is never NULL, so this is a false positive, but it breaks the build for newer toolchains.

Copy the structures with a plain aggregate assignment instead of memcpy(). The assignment is a by-value copy of the whole structure - it copies the entire object, including the embedded union, exactly as the old memcpy(..., sizeof(struct v4l2_format)) did. It lets the compiler derive the size from the type and is not subject to the string/memory builtin diagnostics, so it both fixes the build and is more idiomatic.

No functional change intended.

Assisted-by: Claude:claude-opus-4.8