### PR TITLE
video: driver: classify video-mem as DDR bus type

### DIFF
--- a/driver/vidc/inc/msm_vidc_power.h
+++ b/driver/vidc/inc/msm_vidc_power.h
@@ -56,7 +56,7 @@ static inline u32 get_type_frm_name(const char *name)
 {
 	if (!strcmp(name, "venus-llcc"))
 		return LLCC;
-	else if (!strcmp(name, "venus-ddr"))
+	else if (!strcmp(name, "venus-ddr") || !strcmp(name, "video-mem"))
 		return DDR;
 	else
 		return PERF;


### PR DESCRIPTION
Identify "video-mem" as a DDR bus type in the power helper function get_type_frm_name().

Without this, any interconnect bus named "video-mem" is classified as PERF, which defaults to voting for the maximum static bandwidth. Correctly classifying "video-mem" as DDR allows the driver to vote dynamically for DDR bandwidth (bw_ddr) as intended.

Change-Id: I5f8ac6b0319886883c596828e2c30b16d3413924