### PR TITLE
video: driver: Update firmware to support 32 sessions on Lemans

### DIFF
--- a/platform/sa8775p/src/msm_vidc_sa8775p.c
+++ b/platform/sa8775p/src/msm_vidc_sa8775p.c
@@ -2610,7 +2610,7 @@ static const struct msm_vidc_platform_data sa8775p_data = {
 	.freq_tbl_size = ARRAY_SIZE(sa8775p_freq_table),
 	.reg_prst_tbl = sa8775p_reg_preset_table,
 	.reg_prst_tbl_size = ARRAY_SIZE(sa8775p_reg_preset_table),
-	.fwname = "./qcom/vpu/vpu30_p4_s6.mbn",
+	.fwname = "./qcom/vpu/vpu30_p4_s6_16mb.mbn",
 	.pas_id = 9,
 	.supports_mmrm = 0,
 


### PR DESCRIPTION
Update the LeMans platform configuration to use the 16 MB firmware image to support for up to 32 concurrent
video sessions.

CRs-Fixed: 4548815