### PR TITLE
ci: update package promotion trigger workflow

### DIFF
--- a/.github/workflows/trigger-pkg-promote.yml
+++ b/.github/workflows/trigger-pkg-promote.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Promote New Upstream Version (Suites)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
           script: |
@@ -25,7 +25,7 @@ jobs:
             const [owner, repo] = pkgRepo.split('/');
 
             // Trigger promote-upstream-suites.yml which promotes all three
-            // packaging suites (qcom/debian/latest, qcom/debian/trixie,
+            // packaging suites (qli/debian/latest, qli/debian/trixie,
             // qcom/ubuntu/resolute) in a single workflow run.
             // The ref must point to the branch that contains the workflow file.
             // promote-upstream-suites.yml lives on the 'qli-ci' branch of


### PR DESCRIPTION
Update the upstream tag trigger workflow to use actions/github-script@v9, avoiding the Node 20 deprecation warning from the older action version.

Also refresh the workflow comments to reflect the current packaging branch names, using qli/debian/latest and qli/debian/trixie while keeping qcom/ubuntu/resolute unchanged.