### PR TITLE
iris: update context bank creation to support dt subnodes

### DIFF
--- a/driver/platform/hamoa/src/hamoa.c
+++ b/driver/platform/hamoa/src/hamoa.c
@@ -2028,9 +2028,10 @@ static int msm_vidc_hamoa_init_cb_devs(struct msm_vidc_core *core)
 	static const struct {
 		const char *cb_name;
 		u32 fid;
+		const char *cb_node_name;
 	} hamoa_cb_fid[] = {
-		{ "qcom,vidc,cb-ns",     0 },
-		{ "qcom,vidc,cb-ns-pxl", 1 },
+		{ "qcom,vidc,cb-ns",     0, "non-pixel" },
+		{ "qcom,vidc,cb-ns-pxl", 1, "pixel"     },
 	};
 	struct context_bank_info *cb;
 	int i, rc;
@@ -2040,8 +2041,8 @@ static int msm_vidc_hamoa_init_cb_devs(struct msm_vidc_core *core)
 			if (strcmp(cb->name, hamoa_cb_fid[i].cb_name))
 				continue;
 
-			rc = msm_vidc_create_child_device_and_map(core, cb,
-								  hamoa_cb_fid[i].fid);
+			rc = msm_vidc_create_child_device_and_map(core, cb, hamoa_cb_fid[i].fid,
+								  hamoa_cb_fid[i].cb_node_name);
 			if (rc) {
 				d_vpr_e("%s: failed to create child device for %s rc %d\n",
 					__func__, cb->name, rc);

--- a/driver/platform/lemans/src/lemans.c
+++ b/driver/platform/lemans/src/lemans.c
@@ -1995,9 +1995,10 @@ static int msm_vidc_lemans_init_cb_devs(struct msm_vidc_core *core)
 	static const struct {
 		const char *cb_name;
 		u32 fid;
+		const char *cb_node_name;
 	} lemans_cb_fid[] = {
-		{ "qcom,vidc,cb-ns",     0 },
-		{ "qcom,vidc,cb-ns-pxl", 1 },
+		{ "qcom,vidc,cb-ns",     0, "non-pixel" },
+		{ "qcom,vidc,cb-ns-pxl", 1, "pixel"     },
 	};
 	struct context_bank_info *cb;
 	int i, rc;
@@ -2007,8 +2008,8 @@ static int msm_vidc_lemans_init_cb_devs(struct msm_vidc_core *core)
 			if (strcmp(cb->name, lemans_cb_fid[i].cb_name))
 				continue;
 
-			rc = msm_vidc_create_child_device_and_map(core, cb,
-								  lemans_cb_fid[i].fid);
+			rc = msm_vidc_create_child_device_and_map(core, cb, lemans_cb_fid[i].fid,
+								  lemans_cb_fid[i].cb_node_name);
 			if (rc) {
 				d_vpr_e("%s: failed to create child device for %s rc %d\n",
 					__func__, cb->name, rc);

--- a/driver/platform/purwa/src/purwa.c
+++ b/driver/platform/purwa/src/purwa.c
@@ -1960,9 +1960,10 @@ static int msm_vidc_purwa_init_cb_devs(struct msm_vidc_core *core)
 	static const struct {
 		const char *cb_name;
 		u32 fid;
+		const char *cb_node_name;
 	} purwa_cb_fid[] = {
-		{ "qcom,vidc,cb-ns",     0 },
-		{ "qcom,vidc,cb-ns-pxl", 1 },
+		{ "qcom,vidc,cb-ns",     0, "non-pixel" },
+		{ "qcom,vidc,cb-ns-pxl", 1, "pixel"     },
 	};
 	struct context_bank_info *cb;
 	int i, rc;
@@ -1972,8 +1973,8 @@ static int msm_vidc_purwa_init_cb_devs(struct msm_vidc_core *core)
 			if (strcmp(cb->name, purwa_cb_fid[i].cb_name))
 				continue;
 
-			rc = msm_vidc_create_child_device_and_map(core, cb,
-								  purwa_cb_fid[i].fid);
+			rc = msm_vidc_create_child_device_and_map(core, cb, purwa_cb_fid[i].fid,
+								  purwa_cb_fid[i].cb_node_name);
 			if (rc) {
 				d_vpr_e("%s: failed to create child device for %s rc %d\n",
 					__func__, cb->name, rc);

--- a/driver/vidc/inc/msm_vidc_driver.h
+++ b/driver/vidc/inc/msm_vidc_driver.h
@@ -592,8 +592,8 @@ int msm_vidc_smmu_fault_handler(struct iommu_domain *domain,
 				struct device *dev, unsigned long iova,
 				int flags, void *data);
 struct context_bank_info;
-int msm_vidc_create_child_device_and_map(struct msm_vidc_core *core,
-					 struct context_bank_info *cb, u32 fid);
+int msm_vidc_create_child_device_and_map(struct msm_vidc_core *core, struct context_bank_info *cb,
+					 u32 fid, const char *cb_node_name);
 int msm_vidc_trigger_ssr(struct msm_vidc_core *core,
 			 u64 trigger_ssr_val);
 void msm_vidc_ssr_handler(struct work_struct *work);

--- a/driver/vidc/src/firmware.c
+++ b/driver/vidc/src/firmware.c
@@ -359,13 +359,19 @@ int fw_resume(struct msm_vidc_core *core)
 
 int fw_init(struct msm_vidc_core *core)
 {
+	static const char * const fw_node_name[] = { "video-firmware", "firmware" };
 	struct platform_device_info info;
 	struct platform_device *pdev;
 	struct iommu_domain *dom;
 	struct device_node *np;
-	int ret;
+	int i, ret;
 
-	np = of_get_child_by_name(core->pdev->dev.of_node, "video-firmware");
+	for (i = 0; i < ARRAY_SIZE(fw_node_name); i++) {
+		np = of_get_child_by_name(core->pdev->dev.of_node, fw_node_name[i]);
+		if (np)
+			break;
+	}
+
 	if (!np)
 		return 0;
 

--- a/driver/vidc/src/msm_vidc_probe.c
+++ b/driver/vidc/src/msm_vidc_probe.c
@@ -839,10 +839,11 @@ static struct notifier_block msm_vidc_reboot_nb = {
 };
 #endif
 
-int msm_vidc_create_child_device_and_map(struct msm_vidc_core *core,
-					 struct context_bank_info *cb, u32 fid)
+int msm_vidc_create_child_device_and_map(struct msm_vidc_core *core, struct context_bank_info *cb,
+					 u32 fid, const char *cb_node_name)
 {
 	struct platform_device *pdev;
+	struct device_node *dev_node;
 	int ret;
 
 	pdev = platform_device_alloc(cb->name, 0);
@@ -857,11 +858,22 @@ int msm_vidc_create_child_device_and_map(struct msm_vidc_core *core,
 		return ret;
 	}
 
-	ret = of_dma_configure_id(&pdev->dev, core->pdev->dev.of_node,
-				  true, &fid);
+	dev_node = of_get_child_by_name(core->pdev->dev.of_node, cb_node_name);
+	if (dev_node)
+		ret = of_dma_configure_id(&pdev->dev, dev_node, true, NULL);
+	else
+		ret = of_dma_configure_id(&pdev->dev, core->pdev->dev.of_node, true, &fid);
+	of_node_put(dev_node);
+
 	if (ret) {
 		d_vpr_e("%s: of_dma_configure_id failed for %s fid %u ret %d\n",
 			__func__, cb->name, fid, ret);
+		goto error_unregister;
+	}
+
+	/* No IOMMU mapping established; fall back to parent device */
+	if (!device_iommu_mapped(&pdev->dev)) {
+		cb->dev = &core->pdev->dev;
 		goto error_unregister;
 	}
 
@@ -907,10 +919,9 @@ static int msm_vidc_probe_without_context_bank(struct platform_device *pdev,
 	int rc = 0;
 	struct context_bank_info *cb = NULL;
 
-	if (core->platform->data.init_cb_devs &&
-	    of_find_property(pdev->dev.of_node, "iommu-map", NULL)) {
+	if (core->platform->data.init_cb_devs) {
 		/*
-		 * iommu-map present: platform provides init_cb_devs to create
+		 * iommu-map or subnode present: platform provides init_cb_devs to create
 		 * a child platform device for each CB with a valid fid.
 		 */
 		rc = core->platform->data.init_cb_devs(core);


### PR DESCRIPTION
Update context bank initialization to work with both child node based and iommu-map dt configurations, allowing the driver to discover and configure IOMMU mappings from the appropriate dt node. Also ensure context bank devices are initialized only when a valid IOMMU mapping is established.