### PR TITLE
ci: avoid template expansion in promote workflow script

### DIFF
--- a/.github/workflows/trigger-pkg-promote.yml
+++ b/.github/workflows/trigger-pkg-promote.yml
@@ -15,13 +15,15 @@ jobs:
     steps:
       - name: Trigger Promote New Upstream Version (Suites)
         uses: actions/github-script@v9
+        env:
+          PKG_REPO_GITHUB_NAME: ${{ vars.PKG_REPO_GITHUB_NAME }}
         with:
           github-token: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
           script: |
             const tag = context.ref.replace('refs/tags/', '');
             console.log(`New upstream tag detected: ${tag}`);
 
-            const pkgRepo = '${{ vars.PKG_REPO_GITHUB_NAME }}';
+            const pkgRepo = process.env.PKG_REPO_GITHUB_NAME;
             const [owner, repo] = pkgRepo.split('/');
 
             // Trigger promote-upstream-suites.yml which promotes all three


### PR DESCRIPTION
Pass PKG_REPO_GITHUB_NAME through the step environment instead of expanding the repository variable directly inside the github-script body.

