### PR TITLE
video-driver: enable IR_PERIOD capability on Hamoa

### DIFF
--- a/driver/platform/common/inc/msm_vidc_platform.h
+++ b/driver/platform/common/inc/msm_vidc_platform.h
@@ -443,6 +443,7 @@ int msm_vidc_adjust_ltr_count(void *instance, struct v4l2_ctrl *ctrl);
 int msm_vidc_adjust_use_ltr(void *instance, struct v4l2_ctrl *ctrl);
 int msm_vidc_adjust_mark_ltr(void *instance, struct v4l2_ctrl *ctrl);
 int msm_vidc_adjust_delta_based_rc(void *instance, struct v4l2_ctrl *ctrl);
+int msm_vidc_adjust_ir_period(void *instance, struct v4l2_ctrl *ctrl);
 int msm_vidc_adjust_output_order(void *instance, struct v4l2_ctrl *ctrl);
 int msm_vidc_adjust_input_buf_host_max_count(void *instance, struct v4l2_ctrl *ctrl);
 int msm_vidc_adjust_output_buf_host_max_count(void *instance, struct v4l2_ctrl *ctrl);
@@ -505,6 +506,7 @@ int msm_vidc_set_constant_quality(void *instance, enum msm_vidc_inst_capability_
 int msm_vidc_set_vbr_related_properties(void *instance, enum msm_vidc_inst_capability_type cap_id);
 int msm_vidc_set_cbr_related_properties(void *instance, enum msm_vidc_inst_capability_type cap_id);
 int msm_vidc_set_use_and_mark_ltr(void *instance, enum msm_vidc_inst_capability_type cap_id);
+int msm_vidc_set_ir_period(void *instance, enum msm_vidc_inst_capability_type cap_id);
 int msm_vidc_set_nal_length(void *instance, enum msm_vidc_inst_capability_type cap_id);
 int msm_vidc_set_session_priority(void *instance, enum msm_vidc_inst_capability_type cap_id);
 int msm_vidc_set_flip(void *instance, enum msm_vidc_inst_capability_type cap_id);

--- a/driver/platform/common/inc/msm_vidc_platform_ext.h
+++ b/driver/platform/common/inc/msm_vidc_platform_ext.h
@@ -31,12 +31,9 @@ enum msm_vidc_inst_capability_type;
 #define V4L2_CID_MPEG_VIDC_INPUT_RX_FENCE_FD                                 \
 	(V4L2_CID_MPEG_VIDC_BASE + 0x50)
 
-int msm_vidc_adjust_ir_period(void *instance, struct v4l2_ctrl *ctrl);
 int msm_vidc_adjust_dec_frame_rate(void *instance, struct v4l2_ctrl *ctrl);
 int msm_vidc_adjust_dec_operating_rate(void *instance, struct v4l2_ctrl *ctrl);
 int msm_vidc_adjust_delivery_mode(void *instance, struct v4l2_ctrl *ctrl);
-int msm_vidc_set_ir_period(void *instance,
-			   enum msm_vidc_inst_capability_type cap_id);
 int msm_vidc_set_signal_color_info(void *instance,
 				   enum msm_vidc_inst_capability_type cap_id);
 int msm_vidc_adjust_csc(void *instance, struct v4l2_ctrl *ctrl);

--- a/driver/platform/common/src/msm_vidc_platform.c
+++ b/driver/platform/common/src/msm_vidc_platform.c
@@ -1455,6 +1455,64 @@ int msm_vidc_adjust_mark_ltr(void *instance, struct v4l2_ctrl *ctrl)
 	return 0;
 }
 
+int msm_vidc_adjust_ir_period(void *instance, struct v4l2_ctrl *ctrl)
+{
+	s32 adjusted_value;
+	s64 all_intra = 0, roi_enable = 0,  pix_fmts = MSM_VIDC_FMT_NONE;
+	struct msm_vidc_inst *inst = (struct msm_vidc_inst *)instance;
+
+	adjusted_value = ctrl ? ctrl->val : inst->capabilities[IR_PERIOD].value;
+
+	if (msm_vidc_get_parent_value(inst, IR_PERIOD, ALL_INTRA,
+				      &all_intra, __func__) ||
+		msm_vidc_get_parent_value(inst, IR_PERIOD, META_ROI_INFO,
+					  &roi_enable, __func__))
+		return -EINVAL;
+
+	if (all_intra) {
+		adjusted_value = 0;
+		i_vpr_h(inst, "%s: intra refresh unsupported, all intra: %lld\n",
+			__func__, all_intra);
+		goto exit;
+	}
+
+	if (roi_enable) {
+		i_vpr_h(inst,
+			"%s: intra refresh unsupported with roi metadata\n",
+			__func__);
+		adjusted_value = 0;
+		goto exit;
+	}
+
+	if (inst->codec == MSM_VIDC_HEVC) {
+		if (msm_vidc_get_parent_value(inst, IR_PERIOD,
+					      PIX_FMTS, &pix_fmts, __func__))
+			return -EINVAL;
+
+		if (is_10bit_colorformat(pix_fmts)) {
+			i_vpr_h(inst,
+				"%s: intra refresh is supported only for 8 bit\n",
+				__func__);
+			adjusted_value = 0;
+			goto exit;
+		}
+	}
+
+	/*
+	 * BITRATE_MODE dependency is NOT common across all chipsets.
+	 * Hence, do not return error if not specified as one of the parent.
+	 */
+	if (is_parent_available(inst, IR_PERIOD, BITRATE_MODE, __func__) &&
+	    inst->hfi_rc_type != HFI_RC_CBR_CFR &&
+	    inst->hfi_rc_type != HFI_RC_CBR_VFR)
+		adjusted_value = 0;
+
+exit:
+	msm_vidc_update_cap_value(inst, IR_PERIOD, adjusted_value, __func__);
+
+	return 0;
+}
+
 int msm_vidc_adjust_delta_based_rc(void *instance, struct v4l2_ctrl *ctrl)
 {
 	s32 adjusted_value;
@@ -3585,6 +3643,43 @@ int msm_vidc_set_use_and_mark_ltr(void *instance,
 
 	rc = msm_vidc_packetize_control(inst, cap_id, HFI_PAYLOAD_U32,
 					&hfi_value, sizeof(u32), __func__);
+
+	return rc;
+}
+
+int msm_vidc_set_ir_period(void *instance,
+			   enum msm_vidc_inst_capability_type cap_id)
+{
+	int rc = 0;
+	struct msm_vidc_inst *inst = (struct msm_vidc_inst *)instance;
+	u32 ir_type = 0;
+	struct msm_vidc_core *core;
+
+	core = inst->core;
+
+	if (inst->capabilities[IR_TYPE].value ==
+	    V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD_TYPE_RANDOM) {
+		if (inst->bufq[OUTPUT_PORT].vb2q->streaming) {
+			i_vpr_h(inst, "%s: dynamic random intra refresh not allowed\n",
+				__func__);
+			return 0;
+		}
+		ir_type = HFI_PROP_IR_RANDOM_PERIOD;
+	} else if (inst->capabilities[IR_TYPE].value ==
+		   V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD_TYPE_CYCLIC) {
+		ir_type = HFI_PROP_IR_CYCLIC_PERIOD;
+	} else {
+		i_vpr_e(inst, "%s: invalid ir_type %lld\n",
+			__func__, inst->capabilities[IR_TYPE].value);
+		return -EINVAL;
+	}
+
+	rc = venus_hfi_set_ir_period(inst, ir_type, cap_id);
+	if (rc) {
+		i_vpr_e(inst, "%s: failed to set ir period %lld\n",
+			__func__, inst->capabilities[IR_PERIOD].value);
+		return rc;
+	}
 
 	return rc;
 }

--- a/driver/platform/common/src/msm_vidc_platform_ext.c
+++ b/driver/platform/common/src/msm_vidc_platform_ext.c
@@ -33,64 +33,6 @@ static void v4l2_fence_info_from_driver(
 	memcpy(&v4l2_finfo->handle, &vidc_finfo->handle, sizeof(u64) * v4l2_finfo->num_tx_fds);
 }
 
-int msm_vidc_adjust_ir_period(void *instance, struct v4l2_ctrl *ctrl)
-{
-	s32 adjusted_value;
-	s64 all_intra = 0, roi_enable = 0,  pix_fmts = MSM_VIDC_FMT_NONE;
-	struct msm_vidc_inst *inst = (struct msm_vidc_inst *)instance;
-
-	adjusted_value = ctrl ? ctrl->val : inst->capabilities[IR_PERIOD].value;
-
-	if (msm_vidc_get_parent_value(inst, IR_PERIOD, ALL_INTRA,
-				      &all_intra, __func__) ||
-		msm_vidc_get_parent_value(inst, IR_PERIOD, META_ROI_INFO,
-					  &roi_enable, __func__))
-		return -EINVAL;
-
-	if (all_intra) {
-		adjusted_value = 0;
-		i_vpr_h(inst, "%s: intra refresh unsupported, all intra: %lld\n",
-			__func__, all_intra);
-		goto exit;
-	}
-
-	if (roi_enable) {
-		i_vpr_h(inst,
-			"%s: intra refresh unsupported with roi metadata\n",
-			__func__);
-		adjusted_value = 0;
-		goto exit;
-	}
-
-	if (inst->codec == MSM_VIDC_HEVC) {
-		if (msm_vidc_get_parent_value(inst, IR_PERIOD,
-					      PIX_FMTS, &pix_fmts, __func__))
-			return -EINVAL;
-
-		if (is_10bit_colorformat(pix_fmts)) {
-			i_vpr_h(inst,
-				"%s: intra refresh is supported only for 8 bit\n",
-				__func__);
-			adjusted_value = 0;
-			goto exit;
-		}
-	}
-
-	/*
-	 * BITRATE_MODE dependency is NOT common across all chipsets.
-	 * Hence, do not return error if not specified as one of the parent.
-	 */
-	if (is_parent_available(inst, IR_PERIOD, BITRATE_MODE, __func__) &&
-	    inst->hfi_rc_type != HFI_RC_CBR_CFR &&
-	    inst->hfi_rc_type != HFI_RC_CBR_VFR)
-		adjusted_value = 0;
-
-exit:
-	msm_vidc_update_cap_value(inst, IR_PERIOD, adjusted_value, __func__);
-
-	return 0;
-}
-
 int msm_vidc_adjust_dec_frame_rate(void *instance, struct v4l2_ctrl *ctrl)
 {
 	struct msm_vidc_inst *inst = (struct msm_vidc_inst *)instance;
@@ -145,43 +87,6 @@ int msm_vidc_adjust_delivery_mode(void *instance, struct v4l2_ctrl *ctrl)
 	msm_vidc_update_cap_value(inst, DELIVERY_MODE, adjusted_value, __func__);
 
 	return 0;
-}
-
-int msm_vidc_set_ir_period(void *instance,
-			   enum msm_vidc_inst_capability_type cap_id)
-{
-	int rc = 0;
-	struct msm_vidc_inst *inst = (struct msm_vidc_inst *)instance;
-	u32 ir_type = 0;
-	struct msm_vidc_core *core;
-
-	core = inst->core;
-
-	if (inst->capabilities[IR_TYPE].value ==
-	    V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD_TYPE_RANDOM) {
-		if (inst->bufq[OUTPUT_PORT].vb2q->streaming) {
-			i_vpr_h(inst, "%s: dynamic random intra refresh not allowed\n",
-				__func__);
-			return 0;
-		}
-		ir_type = HFI_PROP_IR_RANDOM_PERIOD;
-	} else if (inst->capabilities[IR_TYPE].value ==
-		   V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD_TYPE_CYCLIC) {
-		ir_type = HFI_PROP_IR_CYCLIC_PERIOD;
-	} else {
-		i_vpr_e(inst, "%s: invalid ir_type %lld\n",
-			__func__, inst->capabilities[IR_TYPE].value);
-		return -EINVAL;
-	}
-
-	rc = venus_hfi_set_ir_period(inst, ir_type, cap_id);
-	if (rc) {
-		i_vpr_e(inst, "%s: failed to set ir period %lld\n",
-			__func__, inst->capabilities[IR_PERIOD].value);
-		return rc;
-	}
-
-	return rc;
 }
 
 int msm_vidc_set_signal_color_info(void *instance,

--- a/driver/platform/hamoa/src/hamoa.c
+++ b/driver/platform/hamoa/src/hamoa.c
@@ -661,6 +661,13 @@ static struct msm_platform_inst_capability instance_cap_data_hamoa[] = {
 		0,
 		CAP_FLAG_OUTPUT_PORT | CAP_FLAG_MENU},
 
+	{IR_PERIOD, ENC, H264 | HEVC,
+		0, INT_MAX, 1, 0,
+		V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD,
+		0,
+		CAP_FLAG_INPUT_PORT | CAP_FLAG_OUTPUT_PORT |
+		CAP_FLAG_DYNAMIC_ALLOWED},
+
 	{AU_DELIMITER, ENC, H264 | HEVC,
 		0, 1, 1, 0,
 		V4L2_CID_MPEG_VIDEO_AU_DELIMITER,
@@ -1403,6 +1410,12 @@ static struct msm_platform_inst_capability instance_cap_data_hamoa[] = {
 		0,
 		CAP_FLAG_OUTPUT_PORT},
 
+	{META_ROI_INFO, ENC, H264 | HEVC,
+		0, 0, 0, 0,
+		0,
+		0,
+		CAP_FLAG_INPUT_PORT | CAP_FLAG_BITMASK | CAP_FLAG_META},
+
 	{COMPLEXITY, ENC, H264 | HEVC,
 		0, 100,
 		1, DEFAULT_COMPLEXITY,
@@ -1429,11 +1442,11 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_hamo
 	 */
 
 	{PIX_FMTS, ENC, H264,
-		{BIT_DEPTH}},
+		{META_ROI_INFO, IR_PERIOD, BIT_DEPTH}},
 
 	{PIX_FMTS, ENC, HEVC,
-		{PROFILE, MIN_FRAME_QP, MAX_FRAME_QP, I_FRAME_QP, P_FRAME_QP,
-			B_FRAME_QP, MIN_QUALITY, BLUR_TYPES, LTR_COUNT, BIT_DEPTH}},
+		{PROFILE, MIN_FRAME_QP, MAX_FRAME_QP, I_FRAME_QP, P_FRAME_QP, B_FRAME_QP,
+		 META_ROI_INFO, MIN_QUALITY, BLUR_TYPES, IR_PERIOD, LTR_COUNT, BIT_DEPTH}},
 
 	{PIX_FMTS, DEC, HEVC,
 		{PROFILE}},
@@ -1498,20 +1511,16 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_hamo
 		msm_vidc_set_bitrate},
 
 	{BITRATE_MODE, ENC, H264,
-		{LTR_COUNT, I_FRAME_QP, P_FRAME_QP,
-			B_FRAME_QP, ENH_LAYER_COUNT, BIT_RATE,
-			MIN_QUALITY, VBV_DELAY,
-			PEAK_BITRATE, SLICE_MODE, CONTENT_ADAPTIVE_CODING,
-			BLUR_TYPES, LOWLATENCY_MODE},
+		{LTR_COUNT, IR_PERIOD, I_FRAME_QP, P_FRAME_QP, B_FRAME_QP, ENH_LAYER_COUNT,
+		 BIT_RATE, META_ROI_INFO, MIN_QUALITY, VBV_DELAY, PEAK_BITRATE, SLICE_MODE,
+		 CONTENT_ADAPTIVE_CODING, BLUR_TYPES, LOWLATENCY_MODE},
 		msm_vidc_adjust_bitrate_mode,
 		msm_vidc_set_u32_enum},
 
 	{BITRATE_MODE, ENC, HEVC,
-		{LTR_COUNT, I_FRAME_QP, P_FRAME_QP,
-			B_FRAME_QP, CONSTANT_QUALITY, ENH_LAYER_COUNT,
-			BIT_RATE, MIN_QUALITY, VBV_DELAY,
-			PEAK_BITRATE, SLICE_MODE, CONTENT_ADAPTIVE_CODING,
-			BLUR_TYPES, LOWLATENCY_MODE, OPEN_GOP},
+		{LTR_COUNT, IR_PERIOD, I_FRAME_QP, P_FRAME_QP, B_FRAME_QP, CONSTANT_QUALITY,
+		 ENH_LAYER_COUNT, BIT_RATE, META_ROI_INFO, MIN_QUALITY, VBV_DELAY, PEAK_BITRATE,
+		 SLICE_MODE, CONTENT_ADAPTIVE_CODING, BLUR_TYPES, LOWLATENCY_MODE, OPEN_GOP},
 		msm_vidc_adjust_bitrate_mode,
 		msm_vidc_set_u32_enum},
 
@@ -1564,6 +1573,11 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_hamo
 		{0},
 		msm_vidc_adjust_mark_ltr,
 		msm_vidc_set_use_and_mark_ltr},
+
+	{IR_PERIOD, ENC, H264 | HEVC,
+		{0},
+		msm_vidc_adjust_ir_period,
+		msm_vidc_set_ir_period},
 
 	{AU_DELIMITER, ENC, H264 | HEVC,
 		{0},
@@ -1850,8 +1864,13 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_hamo
 		msm_vidc_set_u32},
 
 	{ALL_INTRA, ENC, H264 | HEVC,
-		{LTR_COUNT, SLICE_MODE, BIT_RATE},
+		{LTR_COUNT, IR_PERIOD, SLICE_MODE, BIT_RATE},
 		msm_vidc_adjust_all_intra,
+		NULL},
+
+	{META_ROI_INFO, ENC, H264 | HEVC,
+		{MIN_QUALITY, IR_PERIOD, BLUR_TYPES},
+		NULL,
 		NULL},
 };
 

--- a/driver/platform/kodiak/inc/msm_vidc_kodiak.h
+++ b/driver/platform/kodiak/inc/msm_vidc_kodiak.h
@@ -11,9 +11,6 @@ struct msm_vidc_core;
 #if defined(CONFIG_MSM_VIDC_QLI)
 int msm_vidc_get_platform_data_kodiak(struct msm_vidc_core *core);
 int msm_vidc_init_platform_kodiak(struct msm_vidc_core *core);
-int msm_vidc_adjust_ir_period_kodiak(void *instance, struct v4l2_ctrl *ctrl);
-int msm_vidc_set_ir_period_kodiak(void *instance,
-				  enum msm_vidc_inst_capability_type cap_id);
 #else
 int msm_vidc_get_platform_data_kodiak(struct msm_vidc_core *core)
 {
@@ -21,17 +18,6 @@ int msm_vidc_get_platform_data_kodiak(struct msm_vidc_core *core)
 }
 
 int msm_vidc_init_platform_kodiak(struct msm_vidc_core *core)
-{
-	return -EINVAL;
-}
-
-int msm_vidc_adjust_ir_period_kodiak(void *instance, struct v4l2_ctrl *ctrl)
-{
-	return -EINVAL;
-}
-
-int msm_vidc_set_ir_period_kodiak(void *instance,
-				  enum msm_vidc_inst_capability_type cap_id)
 {
 	return -EINVAL;
 }

--- a/driver/platform/kodiak/src/kodiak.c
+++ b/driver/platform/kodiak/src/kodiak.c
@@ -1926,8 +1926,8 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_kodi
 
 	{IR_PERIOD, ENC, H264 | HEVC,
 		{0},
-		msm_vidc_adjust_ir_period_kodiak,
-		msm_vidc_set_ir_period_kodiak},
+		msm_vidc_adjust_ir_period,
+		msm_vidc_set_ir_period},
 
 	{AU_DELIMITER, ENC, H264 | HEVC,
 		{0},
@@ -2495,101 +2495,6 @@ static const struct msm_vidc_platform_data kodiak_data_v0 = {
 	.efuse_data_size = ARRAY_SIZE(efuse_data_kodiak),
 	.sku_version = SKU_VERSION_0,
 };
-
-int msm_vidc_adjust_ir_period_kodiak(void *instance, struct v4l2_ctrl *ctrl)
-{
-	s32 adjusted_value;
-	s64 all_intra = 0, roi_enable = 0,  pix_fmts = MSM_VIDC_FMT_NONE;
-	struct msm_vidc_inst *inst = (struct msm_vidc_inst *)instance;
-
-	adjusted_value = ctrl ? ctrl->val : inst->capabilities[IR_PERIOD].value;
-
-	if (msm_vidc_get_parent_value(inst, IR_PERIOD, ALL_INTRA,
-				      &all_intra, __func__) ||
-		msm_vidc_get_parent_value(inst, IR_PERIOD, META_ROI_INFO,
-					  &roi_enable, __func__))
-		return -EINVAL;
-
-	if (all_intra) {
-		adjusted_value = 0;
-		i_vpr_h(inst, "%s: intra refresh unsupported, all intra: %lld\n",
-			__func__, all_intra);
-		goto exit;
-	}
-
-	if (roi_enable) {
-		i_vpr_h(inst,
-			"%s: intra refresh unsupported with roi metadata\n",
-			__func__);
-		adjusted_value = 0;
-		goto exit;
-	}
-
-	if (inst->codec == MSM_VIDC_HEVC) {
-		if (msm_vidc_get_parent_value(inst, IR_PERIOD,
-					      PIX_FMTS, &pix_fmts, __func__))
-			return -EINVAL;
-
-		if (is_10bit_colorformat(pix_fmts)) {
-			i_vpr_h(inst,
-				"%s: intra refresh is supported only for 8 bit\n",
-				__func__);
-			adjusted_value = 0;
-			goto exit;
-		}
-	}
-
-	/*
-	 * BITRATE_MODE dependency is NOT common across all chipsets.
-	 * Hence, do not return error if not specified as one of the parent.
-	 */
-	if (is_parent_available(inst, IR_PERIOD, BITRATE_MODE, __func__) &&
-	    inst->hfi_rc_type != HFI_RC_CBR_CFR &&
-	    inst->hfi_rc_type != HFI_RC_CBR_VFR)
-		adjusted_value = 0;
-
-exit:
-	msm_vidc_update_cap_value(inst, IR_PERIOD, adjusted_value, __func__);
-
-	return 0;
-}
-
-int msm_vidc_set_ir_period_kodiak(void *instance,
-				  enum msm_vidc_inst_capability_type cap_id)
-{
-	int rc = 0;
-	struct msm_vidc_inst *inst = (struct msm_vidc_inst *)instance;
-	u32 ir_type = 0;
-	struct msm_vidc_core *core;
-
-	core = inst->core;
-
-	if (inst->capabilities[IR_TYPE].value ==
-	    V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD_TYPE_RANDOM) {
-		if (inst->bufq[OUTPUT_PORT].vb2q->streaming) {
-			i_vpr_h(inst, "%s: dynamic random intra refresh not allowed\n",
-				__func__);
-			return 0;
-		}
-		ir_type = HFI_PROP_IR_RANDOM_PERIOD;
-	} else if (inst->capabilities[IR_TYPE].value ==
-		   V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD_TYPE_CYCLIC) {
-		ir_type = HFI_PROP_IR_CYCLIC_PERIOD;
-	} else {
-		i_vpr_e(inst, "%s: invalid ir_type %lld\n",
-			__func__, inst->capabilities[IR_TYPE].value);
-		return -EINVAL;
-	}
-
-	rc = venus_hfi_set_ir_period(inst, ir_type, cap_id);
-	if (rc) {
-		i_vpr_e(inst, "%s: failed to set ir period %lld\n",
-			__func__, inst->capabilities[IR_PERIOD].value);
-		return rc;
-	}
-
-	return rc;
-}
 
 int msm_vidc_get_platform_data_kodiak(struct msm_vidc_core *core)
 {

--- a/driver/platform/lemans/inc/msm_vidc_lemans.h
+++ b/driver/platform/lemans/inc/msm_vidc_lemans.h
@@ -13,9 +13,6 @@ struct msm_vidc_core;
 	defined(CONFIG_MSM_VIDC_QLI)
 int msm_vidc_get_platform_data_lemans(struct msm_vidc_core *core);
 int msm_vidc_init_platform_lemans(struct msm_vidc_core *core);
-int msm_vidc_adjust_ir_period_lemans(void *instance, struct v4l2_ctrl *ctrl);
-int msm_vidc_set_ir_period_lemans(void *instance,
-				  enum msm_vidc_inst_capability_type cap_id);
 #else
 int msm_vidc_get_platform_data_lemans(struct msm_vidc_core *core)
 {
@@ -26,18 +23,6 @@ int msm_vidc_init_platform_lemans(struct msm_vidc_core *core)
 {
 	return -EINVAL;
 }
-
-int msm_vidc_adjust_ir_period_lemans(void *instance, struct v4l2_ctrl *ctrl)
-{
-	return -EINVAL;
-}
-
-int msm_vidc_set_ir_period_lemans(void *instance,
-				  enum msm_vidc_inst_capability_type cap_id)
-{
-	return -EINVAL;
-}
-
 #endif
 
 #endif // _MSM_VIDC_LEMANS_H_

--- a/driver/platform/lemans/src/lemans.c
+++ b/driver/platform/lemans/src/lemans.c
@@ -1519,8 +1519,8 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_lema
 
 	{IR_PERIOD, ENC, H264 | HEVC,
 		{0},
-		msm_vidc_adjust_ir_period_lemans,
-		msm_vidc_set_ir_period_lemans},
+		msm_vidc_adjust_ir_period,
+		msm_vidc_set_ir_period},
 
 	{AU_DELIMITER, ENC, H264 | HEVC,
 		{0},
@@ -2090,101 +2090,6 @@ static const struct msm_vidc_platform_data lemans_data = {
 static int msm_vidc_lemans_check_ddr_type(void)
 {
 	return 0;
-}
-
-int msm_vidc_adjust_ir_period_lemans(void *instance, struct v4l2_ctrl *ctrl)
-{
-	s32 adjusted_value;
-	s64 all_intra = 0, roi_enable = 0,  pix_fmts = MSM_VIDC_FMT_NONE;
-	struct msm_vidc_inst *inst = (struct msm_vidc_inst *)instance;
-
-	adjusted_value = ctrl ? ctrl->val : inst->capabilities[IR_PERIOD].value;
-
-	if (msm_vidc_get_parent_value(inst, IR_PERIOD, ALL_INTRA,
-				      &all_intra, __func__) ||
-		msm_vidc_get_parent_value(inst, IR_PERIOD, META_ROI_INFO,
-					  &roi_enable, __func__))
-		return -EINVAL;
-
-	if (all_intra) {
-		adjusted_value = 0;
-		i_vpr_h(inst, "%s: intra refresh unsupported, all intra: %lld\n",
-			__func__, all_intra);
-		goto exit;
-	}
-
-	if (roi_enable) {
-		i_vpr_h(inst,
-			"%s: intra refresh unsupported with roi metadata\n",
-			__func__);
-		adjusted_value = 0;
-		goto exit;
-	}
-
-	if (inst->codec == MSM_VIDC_HEVC) {
-		if (msm_vidc_get_parent_value(inst, IR_PERIOD,
-					      PIX_FMTS, &pix_fmts, __func__))
-			return -EINVAL;
-
-		if (is_10bit_colorformat(pix_fmts)) {
-			i_vpr_h(inst,
-				"%s: intra refresh is supported only for 8 bit\n",
-				__func__);
-			adjusted_value = 0;
-			goto exit;
-		}
-	}
-
-	/*
-	 * BITRATE_MODE dependency is NOT common across all chipsets.
-	 * Hence, do not return error if not specified as one of the parent.
-	 */
-	if (is_parent_available(inst, IR_PERIOD, BITRATE_MODE, __func__) &&
-	    inst->hfi_rc_type != HFI_RC_CBR_CFR &&
-	    inst->hfi_rc_type != HFI_RC_CBR_VFR)
-		adjusted_value = 0;
-
-exit:
-	msm_vidc_update_cap_value(inst, IR_PERIOD, adjusted_value, __func__);
-
-	return 0;
-}
-
-int msm_vidc_set_ir_period_lemans(void *instance,
-				  enum msm_vidc_inst_capability_type cap_id)
-{
-	int rc = 0;
-	struct msm_vidc_inst *inst = (struct msm_vidc_inst *)instance;
-	u32 ir_type = 0;
-	struct msm_vidc_core *core;
-
-	core = inst->core;
-
-	if (inst->capabilities[IR_TYPE].value ==
-	    V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD_TYPE_RANDOM) {
-		if (inst->bufq[OUTPUT_PORT].vb2q->streaming) {
-			i_vpr_h(inst, "%s: dynamic random intra refresh not allowed\n",
-				__func__);
-			return 0;
-		}
-		ir_type = HFI_PROP_IR_RANDOM_PERIOD;
-	} else if (inst->capabilities[IR_TYPE].value ==
-		   V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD_TYPE_CYCLIC) {
-		ir_type = HFI_PROP_IR_CYCLIC_PERIOD;
-	} else {
-		i_vpr_e(inst, "%s: invalid ir_type %lld\n",
-			__func__, inst->capabilities[IR_TYPE].value);
-		return -EINVAL;
-	}
-
-	rc = venus_hfi_set_ir_period(inst, ir_type, cap_id);
-	if (rc) {
-		i_vpr_e(inst, "%s: failed to set ir period %lld\n",
-			__func__, inst->capabilities[IR_PERIOD].value);
-		return rc;
-	}
-
-	return rc;
 }
 
 int msm_vidc_get_platform_data_lemans(struct msm_vidc_core *core)

--- a/driver/platform/monaco/inc/msm_vidc_monaco.h
+++ b/driver/platform/monaco/inc/msm_vidc_monaco.h
@@ -12,9 +12,6 @@ struct msm_vidc_core;
 #if defined(CONFIG_MSM_VIDC_QLI)
 int msm_vidc_get_platform_data_monaco(struct msm_vidc_core *core);
 int msm_vidc_init_platform_monaco(struct msm_vidc_core *core);
-int msm_vidc_adjust_ir_period_monaco(void *instance, struct v4l2_ctrl *ctrl);
-int msm_vidc_set_ir_period_monaco(void *instance,
-				  enum msm_vidc_inst_capability_type cap_id);
 #else
 int msm_vidc_get_platform_data_monaco(struct msm_vidc_core *core)
 {
@@ -22,17 +19,6 @@ int msm_vidc_get_platform_data_monaco(struct msm_vidc_core *core)
 }
 
 int msm_vidc_init_platform_monaco(struct msm_vidc_core *core)
-{
-	return -EINVAL;
-}
-
-int msm_vidc_adjust_ir_period_monaco(void *instance, struct v4l2_ctrl *ctrl)
-{
-	return -EINVAL;
-}
-
-int msm_vidc_set_ir_period_monaco(void *instance,
-				  enum msm_vidc_inst_capability_type cap_id)
 {
 	return -EINVAL;
 }

--- a/driver/platform/monaco/src/monaco.c
+++ b/driver/platform/monaco/src/monaco.c
@@ -1506,8 +1506,8 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_mona
 
 	{IR_PERIOD, ENC, H264 | HEVC,
 		{0},
-		msm_vidc_adjust_ir_period_monaco,
-		msm_vidc_set_ir_period_monaco},
+		msm_vidc_adjust_ir_period,
+		msm_vidc_set_ir_period},
 
 	{AU_DELIMITER, ENC, H264 | HEVC,
 		{0},
@@ -2045,101 +2045,6 @@ static const struct msm_vidc_platform_data monaco_data = {
 static int msm_vidc_monaco_check_ddr_type(void)
 {
 	return 0;
-}
-
-int msm_vidc_adjust_ir_period_monaco(void *instance, struct v4l2_ctrl *ctrl)
-{
-	s32 adjusted_value;
-	s64 all_intra = 0, roi_enable = 0,  pix_fmts = MSM_VIDC_FMT_NONE;
-	struct msm_vidc_inst *inst = (struct msm_vidc_inst *)instance;
-
-	adjusted_value = ctrl ? ctrl->val : inst->capabilities[IR_PERIOD].value;
-
-	if (msm_vidc_get_parent_value(inst, IR_PERIOD, ALL_INTRA,
-				      &all_intra, __func__) ||
-		msm_vidc_get_parent_value(inst, IR_PERIOD, META_ROI_INFO,
-					  &roi_enable, __func__))
-		return -EINVAL;
-
-	if (all_intra) {
-		adjusted_value = 0;
-		i_vpr_h(inst, "%s: intra refresh unsupported, all intra: %lld\n",
-			__func__, all_intra);
-		goto exit;
-	}
-
-	if (roi_enable) {
-		i_vpr_h(inst,
-			"%s: intra refresh unsupported with roi metadata\n",
-			__func__);
-		adjusted_value = 0;
-		goto exit;
-	}
-
-	if (inst->codec == MSM_VIDC_HEVC) {
-		if (msm_vidc_get_parent_value(inst, IR_PERIOD,
-					      PIX_FMTS, &pix_fmts, __func__))
-			return -EINVAL;
-
-		if (is_10bit_colorformat(pix_fmts)) {
-			i_vpr_h(inst,
-				"%s: intra refresh is supported only for 8 bit\n",
-				__func__);
-			adjusted_value = 0;
-			goto exit;
-		}
-	}
-
-	/*
-	 * BITRATE_MODE dependency is NOT common across all chipsets.
-	 * Hence, do not return error if not specified as one of the parent.
-	 */
-	if (is_parent_available(inst, IR_PERIOD, BITRATE_MODE, __func__) &&
-	    inst->hfi_rc_type != HFI_RC_CBR_CFR &&
-	    inst->hfi_rc_type != HFI_RC_CBR_VFR)
-		adjusted_value = 0;
-
-exit:
-	msm_vidc_update_cap_value(inst, IR_PERIOD, adjusted_value, __func__);
-
-	return 0;
-}
-
-int msm_vidc_set_ir_period_monaco(void *instance,
-				  enum msm_vidc_inst_capability_type cap_id)
-{
-	int rc = 0;
-	struct msm_vidc_inst *inst = (struct msm_vidc_inst *)instance;
-	u32 ir_type = 0;
-	struct msm_vidc_core *core;
-
-	core = inst->core;
-
-	if (inst->capabilities[IR_TYPE].value ==
-	    V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD_TYPE_RANDOM) {
-		if (inst->bufq[OUTPUT_PORT].vb2q->streaming) {
-			i_vpr_h(inst, "%s: dynamic random intra refresh not allowed\n",
-				__func__);
-			return 0;
-		}
-		ir_type = HFI_PROP_IR_RANDOM_PERIOD;
-	} else if (inst->capabilities[IR_TYPE].value ==
-		   V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD_TYPE_CYCLIC) {
-		ir_type = HFI_PROP_IR_CYCLIC_PERIOD;
-	} else {
-		i_vpr_e(inst, "%s: invalid ir_type %lld\n",
-			__func__, inst->capabilities[IR_TYPE].value);
-		return -EINVAL;
-	}
-
-	rc = venus_hfi_set_ir_period(inst, ir_type, cap_id);
-	if (rc) {
-		i_vpr_e(inst, "%s: failed to set ir period %lld\n",
-			__func__, inst->capabilities[IR_PERIOD].value);
-		return rc;
-	}
-
-	return rc;
 }
 
 int msm_vidc_get_platform_data_monaco(struct msm_vidc_core *core)


### PR DESCRIPTION
Add IR_PERIOD capability support for Hamoa encoder sessions and register the corresponding capability dependencies.
 
Reuse the common IR_PERIOD adjust and set handlers by moving the implementation from platform-specific code into the common platform layer. Update Kodiak, Lemans and Monaco to use the shared implementation and remove duplicated code.

Change-Id: Iffd111abb7f3fd90e0b86edb3a1b440c73de7664

CRs-Fixed: 4622845