### PR TITLE
Fix hamoa slic mode issue

### DIFF
--- a/driver/platform/alor/src/alor.c
+++ b/driver/platform/alor/src/alor.c
@@ -1522,7 +1522,7 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_alor
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264 | HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/canoe/src/canoe.c
+++ b/driver/platform/canoe/src/canoe.c
@@ -1523,7 +1523,7 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_cano
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264 | HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/chora/src/chora.c
+++ b/driver/platform/chora/src/chora.c
@@ -1812,7 +1812,7 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_chor
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264 | HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/hamoa/src/hamoa.c
+++ b/driver/platform/hamoa/src/hamoa.c
@@ -1674,12 +1674,12 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_hamo
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 
 	{ENH_LAYER_COUNT, ENC, HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT, OPEN_GOP},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT, OPEN_GOP},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/kera/src/kera.c
+++ b/driver/platform/kera/src/kera.c
@@ -1444,7 +1444,7 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_kera
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264 | HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/malabar/src/malabar.c
+++ b/driver/platform/malabar/src/malabar.c
@@ -1400,7 +1400,7 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_mala
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264 | HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/niobe/src/niobe.c
+++ b/driver/platform/niobe/src/niobe.c
@@ -1521,7 +1521,7 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_niob
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264 | HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/nordau/src/nordau.c
+++ b/driver/platform/nordau/src/nordau.c
@@ -1479,7 +1479,7 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_nord
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264 | HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/pineapple/src/pineapple.c
+++ b/driver/platform/pineapple/src/pineapple.c
@@ -1521,7 +1521,7 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_pine
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264 | HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/purwa/src/purwa.c
+++ b/driver/platform/purwa/src/purwa.c
@@ -1585,12 +1585,12 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_purw
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 
 	{ENH_LAYER_COUNT, ENC, HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT, OPEN_GOP},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT, SLICE_MODE, OPEN_GOP},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/seraph/src/seraph.c
+++ b/driver/platform/seraph/src/seraph.c
@@ -1518,7 +1518,7 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_sera
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264 | HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/sun/src/sun.c
+++ b/driver/platform/sun/src/sun.c
@@ -1521,7 +1521,7 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_sun[
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264 | HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/driver/platform/tuna/src/tuna.c
+++ b/driver/platform/tuna/src/tuna.c
@@ -1450,7 +1450,7 @@ static struct msm_platform_inst_cap_dependency instance_cap_dependency_data_tuna
 		{CONTENT_ADAPTIVE_CODING}},
 
 	{ENH_LAYER_COUNT, ENC, H264 | HEVC,
-		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, LTR_COUNT},
+		{GOP_SIZE, B_FRAME, BIT_RATE, MIN_QUALITY, SLICE_MODE, LTR_COUNT},
 		msm_vidc_adjust_layer_count,
 		msm_vidc_set_layer_count_and_type},
 

--- a/pkg-iris-vpu/debian/iris-vpu-load.sh
+++ b/pkg-iris-vpu/debian/iris-vpu-load.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+
 # Called by iris-vpu-dkms.service on every boot.
 # Load iris_vpu module, handling potential errors gracefully.
 lsmod | grep -q iris_vpu || modprobe iris_vpu


### PR DESCRIPTION
ENH_LAYER_COUNT updates can impact slice configuration constraints,
but SLICE_MODE was not included in the dependency table. As a result,
changes to enhancement layer count may not trigger the required
adjustment and validation of slice mode settings.

Include SLICE_MODE in the dependency list so that slice mode is
re-evaluated whenever ENH_LAYER_COUNT is updated, ensuring consistent
capability handling for H.264 and HEVC encoder sessions.

CRs-Fixed: 4629374