### PR TITLE
video-driver: Use measured frame rate for clock scaling

### DIFF
--- a/driver/variant/iris2/src/msm_vidc_power_iris2.c
+++ b/driver/variant/iris2/src/msm_vidc_power_iris2.c
@@ -113,7 +113,7 @@ static int msm_vidc_calc_freq_iris2(struct msm_vidc_inst *inst, u32 data_size )
 	}
 
 	mbpf = msm_vidc_get_mbs_per_frame(inst);
-	fps = msm_vidc_get_fps(inst);
+	fps = inst->max_rate;
 	mbs_per_second = mbpf * fps;
 
 	/*


### PR DESCRIPTION
Use measured frame rate for clock frequency calculation instead of client-declared value in iris2 variant to match actual workload.

CRs-Fixed: 4581572